### PR TITLE
Update agendas data from pipeline and separate lesswrongTags

### DIFF
--- a/scripts/convert-shallow-review-pipeline.js
+++ b/scripts/convert-shallow-review-pipeline.js
@@ -1,0 +1,382 @@
+#!/usr/bin/env node
+
+/**
+ * Convert parsed YAML from gavento/shallow-review pipeline to website format.
+ *
+ * This script transforms the output of the shallow-review parsing pipeline
+ * (https://github.com/gavento/shallow-review) into the format expected by
+ * the shallow-review-website.
+ *
+ * The pipeline parses a markdown document into a flat list of items
+ * (sections and agendas with their papers/outputs). This script restructures
+ * that flat list into a nested hierarchy suitable for the website.
+ *
+ * Input format (from draft_types.py ProcessedDocument):
+ * - source_file: path to the original markdown file
+ * - items: array of DocumentItem objects with:
+ *   - id: unique identifier (e.g., "sec:black_box" or "a:unlearning")
+ *   - name: display name
+ *   - header_level: markdown header level (1-6)
+ *   - parent_id: ID of parent item (null for top-level)
+ *   - content: markdown content/description
+ *   - item_type: "section" or "agenda"
+ *   - agenda_attributes (for agendas only):
+ *     - outputs: array of Paper objects with link_url, title, authors, etc.
+ *     - some_names, orthodox_problems, target_case_id, broad_approach_id, etc.
+ *
+ * Output format (for website src/data/agendas.yaml):
+ * - sections: array of Section objects with:
+ *   - id, name, description
+ *   - agendas: array of Agenda objects with:
+ *     - id, name, summary, theoryOfChange, papers[], etc.
+ *
+ * Usage:
+ *   node scripts/convert-shallow-review-pipeline.js <input.yaml> [output.yaml]
+ *
+ * Example:
+ *   node scripts/convert-shallow-review-pipeline.js \
+ *     ~/Downloads/draft-md-parsed.yaml \
+ *     src/data/agendas.yaml
+ */
+
+const fs = require('fs');
+const yaml = require('js-yaml');
+const path = require('path');
+
+// Helper to convert snake_case to camelCase
+function toCamelCase(str) {
+  return str.replace(/_([a-z])/g, (_, letter) => letter.toUpperCase());
+}
+
+// Convert a name to a slug ID (e.g., "Black-box safety" -> "black-box-safety")
+function toSlugId(name) {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .trim();
+}
+
+// Clean the ID (remove prefixes like "sec:" or "a:")
+function cleanId(id) {
+  return id.replace(/^(sec:|a:)/, '').replace(/:$/, '');
+}
+
+// Convert output item to Paper format
+function convertOutputToPaper(output) {
+  // Skip items without a link URL (these are just notes/comments)
+  if (!output.link_url) {
+    return null;
+  }
+
+  const paper = {
+    title: output.title || output.link_text || 'Untitled',
+    url: output.link_url,
+  };
+
+  // Add authors if present (join array to string)
+  if (output.authors && output.authors.length > 0) {
+    paper.authors = output.authors.join(', ');
+  }
+
+  // Optionally add more metadata
+  if (output.published_year) {
+    paper.year = output.published_year;
+  }
+  if (output.venue) {
+    paper.venue = output.venue;
+  }
+  if (output.kind) {
+    paper.kind = output.kind;
+  }
+
+  return paper;
+}
+
+// Convert see_also array to string
+function convertSeeAlso(seeAlso) {
+  if (!seeAlso || seeAlso.length === 0) return undefined;
+  return seeAlso.join(', ');
+}
+
+// Convert critiques to array format
+function convertCritiques(critiques) {
+  if (!critiques) return undefined;
+  if (Array.isArray(critiques)) return critiques;
+  // If it's a string, return as single-item array
+  return [critiques];
+}
+
+// Convert funded_by to array of IDs
+function convertFundedBy(fundedBy) {
+  if (!fundedBy) return undefined;
+  if (Array.isArray(fundedBy)) {
+    // Already an array - convert to IDs
+    return fundedBy.map(f => toSlugId(f));
+  }
+  // If it's a string, it might be a comma-separated list or markdown links
+  // For now, just return as a note
+  return undefined; // Will need manual curation
+}
+
+// Convert names array to researcher IDs
+function convertNames(names) {
+  if (!names || names.length === 0) return undefined;
+  return names.map(name => toSlugId(name));
+}
+
+// Map of orthodox problem names to IDs (from orthodoxProblems.yaml)
+const ORTHODOX_PROBLEM_MAP = {
+  'value_fragile': '1',
+  'corrigibility_unnatural': '2',
+  'pivotal_dangerous': '3',
+  'goals_misgeneralize': '4',
+  'instrumental_convergence': '5',
+  'plans_incomprehensible': '6',
+  'fool_supervisors': '7',
+  'hack_supervisors': '8',
+  'no_value_handshake': '9',
+  'humanlike_minds_not_safe': '10',
+  'race_dynamics': '11',
+  'exfiltration': '12',
+  'fair_pivotal': '13',
+};
+
+// Convert orthodox_problems to array of problem IDs
+function convertOrthodoxProblems(problems) {
+  if (!problems || problems.length === 0) return undefined;
+
+  const result = [];
+  for (const p of problems) {
+    const pStr = p.toString();
+    // Check if it's already a numeric ID
+    if (/^\d+$/.test(pStr)) {
+      result.push(pStr);
+    } else if (ORTHODOX_PROBLEM_MAP[pStr]) {
+      // Map named problem to ID
+      result.push(ORTHODOX_PROBLEM_MAP[pStr]);
+    }
+    // Skip "Other: ..." entries
+  }
+  return result.length > 0 ? result : undefined;
+}
+
+// Convert target_case_id to website format
+function convertTargetCase(targetCaseId) {
+  if (!targetCaseId) return undefined;
+  // Map common values (input format -> website format)
+  const mapping = {
+    'average_case': 'average-case',
+    'worst_case': 'worst-case',
+    'pessimistic_case': 'pessimistic',
+    'pessimistic': 'pessimistic',
+    'optimistic_case': 'optimistic',
+    'optimistic': 'optimistic',
+    'mixed': 'mixed',
+    'mixed_case': 'mixed',
+  };
+  return mapping[targetCaseId] || targetCaseId;
+}
+
+// Convert broad_approach_id to array
+function convertBroadApproaches(broadApproachId) {
+  if (!broadApproachId) return undefined;
+  // Map input values to website IDs (from broadApproaches.yaml)
+  const mapping = {
+    'engineering': 'engineering',
+    'behavioral': 'behavioral',
+    'behaviorist_science': 'behavioral',  // Pipeline uses this variant
+    'cognitivist_science': 'cognitive',
+    'cognitive': 'cognitive',
+    'maths_philosophy': 'maths-philosophy',
+    'maths-philosophy': 'maths-philosophy',
+    'theoretical': 'theoretical',
+  };
+  const mapped = mapping[broadApproachId] || broadApproachId;
+  return [mapped];
+}
+
+// Main conversion function
+function convertToWebsiteFormat(inputData) {
+  const items = inputData.items;
+
+  // Build a map of items by ID for parent lookups
+  const itemsById = new Map();
+  items.forEach(item => {
+    itemsById.set(item.id, item);
+  });
+
+  // Find all top-level sections (parent_id is null and item_type is section)
+  const topLevelSections = items.filter(
+    item => item.item_type === 'section' && item.parent_id === null
+  );
+
+  // Find all sub-sections (sections with a parent)
+  const subSections = items.filter(
+    item => item.item_type === 'section' && item.parent_id !== null
+  );
+
+  // Find all agendas
+  const agendas = items.filter(item => item.item_type === 'agenda');
+
+  // Build section hierarchy
+  const sections = [];
+
+  // Process each top-level section
+  for (const topSection of topLevelSections) {
+    const section = {
+      id: cleanId(topSection.id),
+      name: topSection.name,
+      description: topSection.content || undefined,
+      agendas: [],
+    };
+
+    // Find agendas that belong directly to this section
+    const directAgendas = agendas.filter(a => a.parent_id === topSection.id);
+
+    // Find sub-sections of this top-level section
+    const childSubSections = subSections.filter(s => s.parent_id === topSection.id);
+
+    // For each sub-section, find its agendas and add them
+    // We'll flatten the hierarchy: sub-section agendas go into the parent section
+    for (const subSection of childSubSections) {
+      const subAgendas = agendas.filter(a => a.parent_id === subSection.id);
+      directAgendas.push(...subAgendas);
+
+      // Also check for deeper nesting (sub-sub-sections)
+      const deeperSections = subSections.filter(s => s.parent_id === subSection.id);
+      for (const deeperSection of deeperSections) {
+        const deeperAgendas = agendas.filter(a => a.parent_id === deeperSection.id);
+        directAgendas.push(...deeperAgendas);
+      }
+    }
+
+    // Convert each agenda to website format
+    for (const agenda of directAgendas) {
+      const attrs = agenda.agenda_attributes || {};
+
+      // Convert outputs to papers
+      const papers = (attrs.outputs || [])
+        .map(convertOutputToPaper)
+        .filter(p => p !== null);
+
+      const convertedAgenda = {
+        id: cleanId(agenda.id),
+        name: agenda.name,
+      };
+
+      // Add optional fields only if they exist
+      if (attrs.one_sentence_summary) {
+        convertedAgenda.summary = attrs.one_sentence_summary;
+      }
+      if (attrs.theory_of_change) {
+        convertedAgenda.theoryOfChange = attrs.theory_of_change;
+      }
+
+      const seeAlso = convertSeeAlso(attrs.see_also);
+      if (seeAlso) {
+        convertedAgenda.seeAlso = seeAlso;
+      }
+
+      const orthodoxProblems = convertOrthodoxProblems(attrs.orthodox_problems);
+      if (orthodoxProblems && orthodoxProblems.length > 0) {
+        convertedAgenda.orthodoxProblems = orthodoxProblems;
+      }
+
+      const targetCase = convertTargetCase(attrs.target_case_id);
+      if (targetCase) {
+        convertedAgenda.targetCase = targetCase;
+      }
+
+      const broadApproaches = convertBroadApproaches(attrs.broad_approach_id);
+      if (broadApproaches) {
+        convertedAgenda.broadApproaches = broadApproaches;
+      }
+
+      const someNames = convertNames(attrs.some_names);
+      if (someNames && someNames.length > 0) {
+        convertedAgenda.someNames = someNames;
+      }
+
+      if (attrs.estimated_ftes) {
+        convertedAgenda.estimatedFTEs = attrs.estimated_ftes;
+      }
+
+      const critiques = convertCritiques(attrs.critiques);
+      if (critiques && critiques.length > 0) {
+        convertedAgenda.critiques = critiques;
+      }
+
+      // Papers are required, but might be empty
+      convertedAgenda.papers = papers;
+
+      section.agendas.push(convertedAgenda);
+    }
+
+    // Only add sections that have agendas
+    if (section.agendas.length > 0) {
+      sections.push(section);
+    }
+  }
+
+  return { sections };
+}
+
+// Main execution
+async function main() {
+  const inputPath = process.argv[2];
+  const outputPath = process.argv[3] || 'converted-agendas.yaml';
+
+  if (!inputPath) {
+    console.error('Usage: node convert-parsed-yaml.js <input.yaml> [output.yaml]');
+    console.error('');
+    console.error('Example:');
+    console.error('  node convert-parsed-yaml.js ~/Downloads/draft-md-20251208-to-parse-parsed.yaml src/data/agendas.yaml');
+    process.exit(1);
+  }
+
+  try {
+    console.log(`Reading input from: ${inputPath}`);
+    const inputContent = fs.readFileSync(inputPath, 'utf8');
+    const inputData = yaml.load(inputContent);
+
+    console.log(`Found ${inputData.items.length} items`);
+
+    const sectionCount = inputData.items.filter(i => i.item_type === 'section').length;
+    const agendaCount = inputData.items.filter(i => i.item_type === 'agenda').length;
+    console.log(`  - ${sectionCount} sections`);
+    console.log(`  - ${agendaCount} agendas`);
+
+    console.log('Converting to website format...');
+    const outputData = convertToWebsiteFormat(inputData);
+
+    console.log(`Converted to ${outputData.sections.length} top-level sections`);
+    let totalAgendas = 0;
+    let totalPapers = 0;
+    for (const section of outputData.sections) {
+      totalAgendas += section.agendas.length;
+      for (const agenda of section.agendas) {
+        totalPapers += agenda.papers.length;
+      }
+    }
+    console.log(`  - ${totalAgendas} agendas total`);
+    console.log(`  - ${totalPapers} papers total`);
+
+    console.log(`Writing output to: ${outputPath}`);
+    const outputContent = yaml.dump(outputData, {
+      lineWidth: 120,
+      noRefs: true,
+      quotingType: '"',
+      forceQuotes: false,
+    });
+    fs.writeFileSync(outputPath, outputContent, 'utf8');
+
+    console.log('Done!');
+  } catch (error) {
+    console.error('Error:', error.message);
+    process.exit(1);
+  }
+}
+
+main();

--- a/src/data/agendaLesswrongTags.yaml
+++ b/src/data/agendaLesswrongTags.yaml
@@ -1,0 +1,78 @@
+# LessWrong tags for agendas
+# This file maps agenda IDs to their LessWrong tag slugs
+# Maintained separately from agendas.yaml for easier updates from the pipeline
+#
+# Note: Agenda IDs use underscores (e.g., cot_monitoring) to match the pipeline output
+
+unlearning:
+  - machine-unlearning
+control:
+  - ai-control
+cot_monitoring:
+  - chain-of-thought-alignment
+surprising_generalization:
+  - deceptive-alignment
+specs_and_constitutions:
+  - constitutional-ai
+psych_personas:
+  - sycophancy
+model_values:
+  - human-values
+hyperstition:
+  - hyperstitions
+rl_safety:
+  - reinforcement-learning
+assistance_games:
+  - center-for-human-compatible-ai-chai
+open_model_interventions:
+  - open-source-ai
+interp_fundamental:
+  - interpretability-ml-and-ai
+  - transformer-circuits
+interp_concept_based:
+  - ai-auditing
+model_diff:
+  - model-diffing
+interp_sparse_coding:
+  - sparse-autoencoders-saes
+interp_causal_abstractions:
+  - causal-scrubbing
+interp_other:
+  - interpretability-ml-and-ai
+activation_engineering:
+  - activation-engineering
+learning_dev_interp:
+  - singular-learning-theory
+aisi_guarantees:
+  - guaranteed-safe-ai
+supervising_improvement:
+  - ai-assisted-alignment
+  - scalable-oversight
+debate:
+  - debate-ai-safety-technique-1
+introspection_training:
+  - scalable-oversight
+agent_foundations:
+  - agent-foundations
+tiling_agents:
+  - tiling-agents
+simulators:
+  - simulator-theory
+arc_theory_formal:
+  - alignment-research-center-arc
+  - eliciting-latent-knowledge
+behavior_alignment_theory:
+  - shard-theory
+corrigibility_other:
+  - corrigibility-1
+natural_abstractions:
+  - natural-abstraction
+learning_theoretic_agenda:
+  - ontology
+aligning_multiple_game_theory:
+  - game-theory
+  - multipolar-scenarios
+aligning_multiple_tools:
+  - multipolar-scenarios
+aligned_to_who:
+  - human-values

--- a/src/data/agendas.yaml
+++ b/src/data/agendas.yaml
@@ -1,48 +1,536 @@
 sections:
-  - id: black-box-safety
-    name: Black-box safety
-    description: Understand and control current model behaviour
+  - id: big_labs
+    name: Labs (giant companies)
+    agendas:
+      - id: openai
+        name: OpenAI Safety
+        seeAlso: sec:iterative_alignment, a:anthropic_safeguards, a:psych_personas
+        someNames:
+          - johannes-heidecke
+          - boaz-barak
+          - mia-glaese
+          - jenny-nitishinskaya
+          - lama-ahmad
+          - naomi-bashkansky
+          - miles-wang
+          - wojciech-zaremba
+          - david-robinson
+          - zico-kolter
+          - jerry-tworek
+          - eric-wallace
+          - olivia-watkins
+          - kai-chen
+          - chris-koch
+          - andrea-vallone
+          - leo-gao
+        critiques:
+          - >-
+            [Stein-Perlman](https://ailabwatch.org/companies/openai),
+            [Stewart](https://intelligence.org/2025/03/31/a-response-to-openais-how-we-think-about-safety-and-alignment/),
+            [underelicitation](https://www.lesswrong.com/posts/AK6AihHGjirdoiJg6/ai-companies-eval-reports-mostly-don-t-support-their-claims),
+            [Midas](https://www.openaifiles.org/transparency-and-safety),
+            [defense](https://www.wired.com/story/openai-anduril-defense/),
+            [Carlsmith](https://joecarlsmith.com/2025/11/03/leaving-open-philanthropy-going-to-anthropic#:~:text=a%20few%20words%20about%20some%20more%20general%20concerns%20about%20AI%2Dsafety%2Dfocused%20people%20going%20to%20work%20at%20AI%20companies%20\(and/or%2C%20at%20Anthropic%20in%20particular\).)
+            on labs in general. It's [difficult](https://conversationswithtyler.com/episodes/sam-altman-2/) to model
+            OpenAI as a single agent: *"ALTMAN: I very rarely get to have anybody work on anything. One thing about
+            researchers is they're going to work on what they're going to work on, and that's that."*
+        papers:
+          - title: Alignment Research Blog
+            url: https://alignment.openai.com/
+            year: 2025
+            venue: OpenAI Alignment Blog
+            kind: blog_post
+          - title: Monitoring Reasoning Models for Misbehavior and the Risks of Promoting Obfuscation
+            url: https://arxiv.org/abs/2503.11926
+            authors: >-
+              Bowen Baker, Joost Huizinga, Leo Gao, Zehao Dou, Melody Y. Guan, Aleksander Madry, Wojciech Zaremba, Jakub
+              Pachocki, David Farhi
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Persona Features Control Emergent Misalignment
+            url: https://arxiv.org/abs/2506.19823
+            authors: >-
+              Miles Wang, Tom Dupré la Tour, Olivia Watkins, Alex Makelov, Ryan A. Chi, Samuel Miserendino, Jeffrey
+              Wang, Achyuta Rajaram, Johannes Heidecke, Tejal Patwardhan, Dan Mossing
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Stress Testing Deliberative Alignment for Anti-Scheming Training
+            url: https://arxiv.org/abs/2509.15541
+            authors: >-
+              Bronson Schoen, Evgenia Nitishinskaya, Mikita Balesni, Axel Højmark, Felix Hofstätter, Jérémy Scheurer,
+              Alexander Meinke, Jason Wolfe, Teun van der Weij, Alex Lloyd, Nicholas Goldowsky-Dill, Angela Fan, Andrei
+              Matveiakin, Rusheb Shah, Marcus Williams, Amelia Glaese, Boaz Barak, Wojciech Zaremba, Marius Hobbhahn
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Deliberative Alignment: Reasoning Enables Safer Language Models"
+            url: https://arxiv.org/abs/2412.16339
+            authors: >-
+              Melody Y. Guan, Manas Joglekar, Eric Wallace, Saachi Jain, Boaz Barak, Alec Helyar, Rachel Dias, Andrea
+              Vallone, Hongyu Ren, Jason Wei, Hyung Won Chung, Sam Toyer, Johannes Heidecke, Alex Beutel, Amelia Glaese
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: Toward understanding and preventing misalignment generalization
+            url: https://openai.com/index/emergent-misalignment
+            authors: >-
+              Miles Wang, Tom Dupré la Tour, Olivia Watkins, Aleksandar Makelov, Ryan A. Chi, Samuel Miserendino, Tejal
+              Patwardhan, Dan Mossing
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Our updated Preparedness Framework
+            url: https://openai.com/index/updating-our-preparedness-framework/
+            authors: OpenAI Preparedness Team
+            year: 2025
+            venue: OpenAI Blog
+            kind: agenda_manifesto
+          - title: Trading Inference-Time Compute for Adversarial Robustness
+            url: https://arxiv.org/abs/2501.18841
+            authors: >-
+              Wojciech Zaremba, Evgenia Nitishinskaya, Boaz Barak, Stephanie Lin, Sam Toyer, Yaodong Yu, Rachel Dias,
+              Eric Wallace, Kai Xiao, Johannes Heidecke, Amelia Glaese
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Findings from a pilot Anthropic–OpenAI alignment evaluation exercise: OpenAI Safety Tests"
+            url: https://openai.com/index/openai-anthropic-safety-evaluation
+            year: 2025
+            venue: OpenAI Blog
+            kind: news_announcement
+          - title: Safety evaluations hub
+            url: https://openai.com/safety/evaluations-hub
+            year: 2025
+            venue: OpenAI Website
+            kind: news_announcement
+          - title: "Small-to-Large Generalization: Data Influences Models Consistently Across Scale"
+            url: https://arxiv.org/abs/2505.16260
+            authors: Alaa Khaddaj, Logan Engstrom, Aleksander Madry
+            year: 2025
+            venue: ICLR 2025
+            kind: paper_published
+          - title: Unknown - PDF content not accessible
+            url: https://cdn.openai.com/pdf/41df8f28-d4ef-43e9-aed2-823f9393e470/circuit-sparsity-paper.pdf
+            kind: error_detected
+      - id: deepmind
+        name: Deepmind Responsibility & Safety
+        seeAlso: sec:interpretability, Scalable Oversight
+        someNames:
+          - rohin-shah
+          - allan-dafoe
+          - anca-dragan
+          - dave-orr
+          - alex-irpan
+          - alex-turner
+          - anna-wang
+          - arthur-conmy
+          - david-lindner
+          - jonah-brown-cohen
+          - lewis-ho
+          - neel-nanda
+          - raluca-ada-popa
+          - rishub-jain
+          - rory-greig
+          - scott-emmons
+          - sebastian-farquhar
+          - senthooran-rajamanoharan
+          - sophie-bridgers
+          - tobi-ijitoye
+          - tom-everitt
+          - victoria-krakovna
+          - vikrant-varma
+          - vladimir-mikulik
+          - zac-kenton
+          - noah-goodman
+          - four-flynn
+          - jonathan-richens
+          - lewis-smith
+        critiques:
+          - >-
+            [Stein-Perlman](https://ailabwatch.org/companies/deepmind),
+            [Carlsmith](https://joecarlsmith.com/2025/11/03/leaving-open-philanthropy-going-to-anthropic#:~:text=a%20few%20words%20about%20some%20more%20general%20concerns%20about%20AI%2Dsafety%2Dfocused%20people%20going%20to%20work%20at%20AI%20companies%20\(and/or%2C%20at%20Anthropic%20in%20particular\).),
+            [underelicitation](https://www.lesswrong.com/posts/AK6AihHGjirdoiJg6/ai-companies-eval-reports-mostly-don-t-support-their-claims),
+            [On Google's Safety Plan](https://lesswrong.com/posts/hvEikwtsbf6zaXG2s/on-google-s-safety-plan)
+        papers:
+          - title: A Pragmatic Vision for Interpretability
+            url: https://www.alignmentforum.org/posts/StENzDcD3kpfGJssR/a-pragmatic-vision-for-interpretability%20
+            authors: >-
+              Neel Nanda, Josh Engels, Arthur Conmy, Senthooran Rajamanoharan, bilalchughtai, CallumMcDougall, János
+              Kramár, lewis smith
+            year: 2025
+            venue: AI Alignment Forum
+            kind: lesswrong
+          - title: How Can Interpretability Researchers Help AGI Go Well?
+            url: >-
+              https://www.alignmentforum.org/posts/MnkeepcGirnJn736j/how-can-interpretability-researchers-help-agi-go-well%20
+            authors: >-
+              Neel Nanda, Josh Engels, Senthooran Rajamanoharan, Arthur Conmy, bilalchughtai, CallumMcDougall, János
+              Kramár, lewis smith
+            year: 2024
+            venue: AI Alignment Forum
+            kind: lesswrong
+          - title: Evaluating Frontier Models for Stealth and Situational Awareness
+            url: https://arxiv.org/abs/2505.01420
+            authors: >-
+              Mary Phuong, Roland S. Zimmermann, Ziyue Wang, David Lindner, Victoria Krakovna, Sarah Cogan, Allan Dafoe,
+              Lewis Ho, Rohin Shah
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: When Chain of Thought is Necessary, Language Models Struggle to Evade Monitors
+            url: https://arxiv.org/abs/2507.05246
+            authors: >-
+              Scott Emmons, Erik Jenner, David K. Elson, Rif A. Saurous, Senthooran Rajamanoharan, Heng Chen, Irhum
+              Shafkat, Rohin Shah
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "MONA: Managed Myopia with Approval Feedback"
+            url: https://alignmentforum.org/posts/zWySWKuXnhMDhgwc3/mona-managed-myopia-with-approval-feedback-2
+            authors: Sebastian Farquhar, David Lindner, Rohin Shah
+            year: 2025
+            venue: AI Alignment Forum
+            kind: lesswrong
+          - title: Consistency Training Helps Stop Sycophancy and Jailbreaks
+            url: https://arxiv.org/abs/2510.27062
+            authors: Alex Irpan, Alexander Matt Turner, Mark Kurzeja, David K. Elson, Rohin Shah
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: An Approach to Technical AGI Safety and Security
+            url: https://arxiv.org/abs/2504.01849
+            authors: >-
+              Rohin Shah, Alex Irpan, Alexander Matt Turner, Anna Wang, Arthur Conmy, David Lindner, Jonah Brown-Cohen,
+              Lewis Ho, Neel Nanda, Raluca Ada Popa, Rishub Jain, Rory Greig, Samuel Albanie, Scott Emmons, Sebastian
+              Farquhar, Sébastien Krier, Senthooran Rajamanoharan, Sophie Bridgers, Tobi Ijitoye, Tom Everitt, Victoria
+              Krakovna, Vikrant Varma, Vladimir Mikulik, Zachary Kenton, Dave Orr, Shane Legg, Noah Goodman, Allan
+              Dafoe, Four Flynn, Anca Dragan
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "InfAlign: Inference-aware language model alignment"
+            url: https://arxiv.org/abs/2412.19792
+            authors: >-
+              Ananth Balashankar, Ziteng Sun, Jonathan Berant, Jacob Eisenstein, Michael Collins, Adrian Hutter, Jong
+              Lee, Chirag Nagpal, Flavien Prost, Aradhana Sinha, Ananda Theertha Suresh, Ahmad Beirami
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: >-
+              Negative Results for SAEs On Downstream Tasks and Deprioritising SAE Research (GDM Mech Interp Team
+              Progress Update #2)
+            url: https://alignmentforum.org/posts/4uXCAJNuPKtKBsi28/negative-results-for-saes-on-downstream-tasks
+            authors: >-
+              Lewis Smith, Senthooran Rajamanoharan, Arthur Conmy, Callum McDougall, Tom Lieberum, János Kramár, Rohin
+              Shah, Neel Nanda
+            year: 2025
+            venue: AI Alignment Forum
+            kind: lesswrong
+          - title: Taking a responsible path to AGI
+            url: https://deepmind.google/discover/blog/taking-a-responsible-path-to-agi/
+            authors: Anca Dragan, Rohin Shah, Four Flynn, Shane Legg
+            year: 2025
+            venue: Google DeepMind Blog
+            kind: blog_post
+          - title: Evaluating potential cybersecurity threats of advanced AI
+            url: https://deepmind.google/discover/blog/evaluating-potential-cybersecurity-threats-of-advanced-ai
+            authors: Four Flynn, Mikel Rodriguez, Raluca Ada Popa
+            year: 2025
+            venue: Google DeepMind Blog
+            kind: blog_post
+          - title: Incentives for Responsiveness, Instrumental Control and Impact
+            url: https://arxiv.org/pdf/2001.07118
+            authors: Ryan Carey, Eric Langlois, Chris van Merwijk, Shane Legg, Tom Everitt
+            year: 2020
+            venue: arXiv
+            kind: paper_preprint
+          - title: Difficulties with Evaluating a Deception Detector for AIs
+            url: https://arxiv.org/html/2511.22662v1
+            authors: Lewis Smith, Bilal Chughtai, Neel Nanda
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+      - id: anthropic
+        name: Anthropic Safety
+        seeAlso: sec:interpretability, Scalable Oversight
+        someNames:
+          - chris-olah
+          - evan-hubinger
+          - sam-marks
+          - johannes-treutlein
+          - sam-bowman
+          - euan-ong
+          - fabien-roger
+          - adam-jermyn
+          - holden-karnofsky
+          - jan-leike
+          - ethan-perez
+          - jack-lindsey
+          - amanda-askell
+          - kyle-fish
+          - sara-price
+          - jon-kutasov
+          - minae-kwon
+          - monty-evans
+          - richard-dargan
+        critiques:
+          - >-
+            [Stein](https://ailabwatch.org/anthropic-opinions)-[Perlman](https://ailabwatch.org/companies/anthropic),
+            [Casper](https://www.lesswrong.com/posts/pH6tyhEnngqWAXi9i/eis-xiii-reflections-on-anthropic-s-sae-research-circa-may#A_review___thoughts),
+            [Carlsmith](https://joecarlsmith.com/2025/11/03/leaving-open-philanthropy-going-to-anthropic#:~:text=a%20few%20words%20about%20some%20more%20general%20concerns%20about%20AI%2Dsafety%2Dfocused%2Dpeople%20going%20to%20work%20at%20AI%20companies%20\(and/or%2C%20at%20Anthropic%20in%20particular\).),
+            [underelicitation](https://www.lesswrong.com/posts/AK6AihHGjirdoiJg6/ai-companies-eval-reports-mostly-don-t-support-their-claims),
+            [Greenblatt](https://nitter.net/RyanPGreenblatt/status/1925992236648464774),
+            [Samin](https://www.lesswrong.com/posts/5aKRshJzhojqfbRyo/unless-its-governance-changes-anthropic-is-untrustworthy),
+            [defense](https://techcrunch.com/2024/11/07/anthropic-teams-up-with-palantir-and-aws-to-sell-its-ai-to-defense-customers/),
+            [Existing Safety Frameworks Imply Unreasonable
+            Confidence](https://lesswrong.com/posts/7ExkgcDudwhag73vw/existing-safety-frameworks-imply-unreasonable-confidence)
+        papers:
+          - title: Natural emergent misalignment from reward hacking
+            url: >-
+              https://assets.anthropic.com/m/74342f2c96095771/original/Natural-emergent-misalignment-from-reward-hacking-paper.pdf
+            kind: error_detected
+          - title: "Agentic Misalignment: How LLMs could be insider threats"
+            url: https://anthropic.com/research/agentic-misalignment
+            authors: >-
+              Aengus Lynch, Benjamin Wright, Caleb Larson, Kevin K. Troy, Stuart J. Ritchie, Sören Mindermann, Ethan
+              Perez, Evan Hubinger
+            year: 2025
+            venue: Anthropic Research
+            kind: blog_post
+          - title: "SHADE-Arena: Evaluating sabotage and monitoring in LLM agents"
+            url: https://anthropic.com/research/shade-arena-sabotage-monitoring
+            authors: >-
+              Xiang Deng, Chen Bo Calvin Zhang, Tyler Tracy, Buck Shlegeris, Yuqi Sun, Paul Colognese, Teun van der
+              Weij, Linda Petrini, Henry Sleight
+            year: 2025
+            venue: Anthropic Research Blog
+            kind: blog_post
+          - title: Forecasting Rare Language Model Behaviors
+            url: https://arxiv.org/abs/2502.16797
+            authors: >-
+              Erik Jones, Meg Tong, Jesse Mu, Mohammed Mahfoud, Jan Leike, Roger Grosse, Jared Kaplan, William Fithian,
+              Ethan Perez, Mrinank Sharma
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Why Do Some Language Models Fake Alignment While Others Don't?
+            url: >-
+              https://alignmentforum.org/posts/ghESoA8mo3fv9Yx3E/why-do-some-language-models-fake-alignment-while-others-don
+            authors: abhayesian, John Hughes, Alex Mallen, Jozdien, janus, Fabien Roger
+            year: 2025
+            venue: arXiv
+            kind: lesswrong
+          - title: "Petri: An open-source auditing tool to accelerate AI safety research"
+            url: https://alignment.anthropic.com/2025/petri
+            year: 2025
+            venue: Anthropic Alignment Science Blog
+            kind: blog_post
+          - title: Signs of introspection in large language models
+            url: https://anthropic.com/research/introspection
+            year: 2025
+            venue: Anthropic Research
+            kind: blog_post
+          - title: Recommendations for Technical AI Safety Research Directions
+            url: https://alignment.anthropic.com/2025/recommended-directions/index.html
+            authors: Anthropic Alignment Science Team
+            year: 2025
+            venue: Alignment Science Blog
+            kind: agenda_manifesto
+          - title: Putting up Bumpers
+            url: https://alignment.anthropic.com/2025/bumpers/
+            year: 2025
+            venue: Anthropic Alignment Science Blog
+            kind: blog_post
+          - title: Three Sketches of ASL-4 Safety Case Components
+            url: https://alignment.anthropic.com/2024/safety-cases/index.html
+            year: 2024
+            venue: Alignment Science Blog
+            kind: blog_post
+          - title: Open-sourcing circuit tracing tools
+            url: https://anthropic.com/research/open-source-circuit-tracing
+            authors: Michael Hanna, Mateusz Piotrowski, Emmanuel Ameisen, Jack Lindsey, Johnny Lin, Curt Tigges
+            year: 2025
+            venue: Anthropic Blog
+            kind: code_tool
+          - title: Poisoning Attacks on LLMs Require a Near-constant Number of Poison Samples
+            url: https://arxiv.org/abs/2510.07192
+            authors: >-
+              Alexandra Souly, Javier Rando, Ed Chapman, Xander Davies, Burak Hasircioglu, Ezzeldin Shereen, Carlos
+              Mougan, Vasilios Mavroudis, Erik Jones, Chris Hicks, Nicholas Carlini, Yarin Gal, Robert Kirk
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Emergent Introspective Awareness in Large Language Models
+            url: https://transformer-circuits.pub/2025/introspection/index.html
+            authors: Jack Lindsey
+            year: 2025
+            venue: Transformer Circuits Thread
+            kind: blog_post
+          - title: Findings from a Pilot Anthropic—OpenAI Alignment Evaluation Exercise
+            url: https://alignment.anthropic.com/2025/openai-findings
+            authors: >-
+              Samuel R. Bowman, Megha Srivastava, Jon Kutasov, Rowan Wang, Trenton Bricken, Benjamin Wright, Ethan
+              Perez, Nicholas Carlini
+            year: 2025
+            venue: Alignment Science Blog
+            kind: blog_post
+          - title: Reasoning models don't always say what they think
+            url: https://www.anthropic.com/research/reasoning-models-dont-say-think
+            year: 2025
+            venue: Anthropic Research Blog
+            kind: blog_post
+          - title: On the Biology of a Large Language Model
+            url: https://transformer-circuits.pub/2025/attribution-graphs/biology.html
+            authors: >-
+              Jack Lindsey, Wes Gurnee, Emmanuel Ameisen, Brian Chen, Adam Pearce, Nicholas L. Turner, Craig Citro,
+              David Abrahams, Shan Carter, Basil Hosmer, Jonathan Marcus, Michael Sklar, Adly Templeton, Trenton
+              Bricken, Callum McDougall, Hoagy Cunningham, Thomas Henighan, Adam Jermyn, Andy Jones, Andrew Persic,
+              Zhenyi Qi, T. Ben Thompson, Sam Zimmerman, Kelley Rivoire, Thomas Conerly, Chris Olah, Joshua Batson
+            year: 2025
+            venue: Transformer Circuits Thread
+            kind: paper_published
+          - title: "Circuit Tracing: Revealing Computational Graphs in Language Models"
+            url: https://transformer-circuits.pub/2025/attribution-graphs/methods.html
+            authors: >-
+              Emmanuel Ameisen, Jack Lindsey, Adam Pearce, Wes Gurnee, Nicholas L. Turner, Brian Chen, Craig Citro,
+              David Abrahams, Shan Carter, Basil Hosmer, Jonathan Marcus, Michael Sklar, Adly Templeton, Trenton
+              Bricken, Callum McDougall, Hoagy Cunningham, Thomas Henighan, Adam Jermyn, Andy Jones, Andrew Persic,
+              Zhenyi Qi, T. Ben Thompson, Sam Zimmerman, Kelley Rivoire, Thomas Conerly, Chris Olah, Joshua Batson
+            year: 2025
+            venue: Transformer Circuits Thread
+            kind: blog_post
+          - title: Auditing language models for hidden objectives
+            url: https://www.anthropic.com/research/auditing-hidden-objectives
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Constitutional Classifiers: Defending against universal jailbreaks"
+            url: https://www.anthropic.com/research/constitutional-classifiers
+            authors: Anthropic Safeguards Research Team
+            year: 2025
+            venue: Anthropic Blog
+            kind: blog_post
+          - title: Claude 4.5 Opus Soul Document
+            url: https://gist.github.com/Richard-Weiss/efe157692991535403bd7e7fb20b6695
+            authors: Richard-Weiss
+            year: 2024
+            venue: GitHub Gist
+            kind: other
+          - title: Evaluating honesty and lie detection techniques on a diverse suite of dishonest models
+            url: https://alignment.anthropic.com/2025/honesty-elicitation/
+            authors: Rowan Wang, Johannes Treutlein, Fabien Roger, Evan Hubinger, Sam Marks
+            year: 2025
+            venue: Anthropic Alignment Science Blog
+            kind: blog_post
+      - id: xai
+        name: xAI
+        someNames:
+          - dan-hendrycks-advisor
+          - juntang-zhuang
+          - toby-pohlen
+          - lianmin-zheng
+          - piaoyang-cui
+          - nikita-popov
+          - ying-sheng
+          - sehoon-kim
+        critiques:
+          - >-
+            [framework](https://www.lesswrong.com/posts/hQyrTDuTXpqkxrnoH/xai-s-new-safety-framework-is-dreadful),
+            [hacking](https://x.com/g_leech_/status/1990543987846078854), [broken
+            promises](https://x.com/g_leech_/status/1990734517145911593),
+            [Stein](https://ailabwatch.org/companies/xai)-[Perlman](https://ailabwatch.org/resources/integrity#xai),
+            [insecurity](https://nitter.net/elonmusk/status/1961904269545648624),
+            [Carlsmith](https://joecarlsmith.com/2025/11/03/leaving-open-philanthropy-going-to-anthropic#:~:text=a%20few%20words%20about%20some%20more%20general%20concerns%20about%20AI%2Dsafety%2Dfocused%20people%20going%20to%20work%20at%20AI%20companies%20\(and/or%2C%20at%20Anthropic%20in%20particular\).)
+            on labs in general
+        papers: []
+      - id: meta
+        name: Meta
+        seeAlso: a:unlearning
+        someNames:
+          - shuchao-bi
+          - hongyuan-zhan
+          - jingyu-zhang
+          - haozhu-wang
+          - eric-michael-smith
+          - sid-wang
+          - amr-sharaf
+          - mahesh-pasupuleti
+          - jason-weston
+          - shengyun-peng
+          - ivan-evtimov
+          - song-jiang
+          - pin-yu-chen
+          - evangelia-spiliopoulou
+          - lei-yu
+          - virginie-do
+          - karen-hambardzumyan
+          - nicola-cancedda
+          - adina-williams
+        critiques:
+          - >-
+            [extreme
+            underelicitation](https://googleprojectzero.blogspot.com/2024/06/project-naptime.html#:~:text=We%20find%20that%2C%20by%20refining%20the%20testing%20methodology%20to%20take%20advantage%20of%20modern%20LLM%20capabilities%2C%20significantly%20better%20performance%20in%20vulnerability%20discovery%20can%20be%20achieved.%20To%20facilitate%20effective%20evaluation%20of%20LLMs%20for%20vulnerability%20discovery%2C%20we%20propose%20below%20a%20set%20of%20guiding%20principles.),
+            [Stein](https://ailabwatch.org/companies/meta)-[Perlman](https://ailabwatch.org/companies/meta),
+            [Carlsmith](https://joecarlsmith.com/2025/11/03/leaving-open-philanthropy-going-to-anthropic#:~:text=a%20few%20words%20about%20some%20more%20general%20concerns%20about%20AI%2Dsafety%2Dfocused%20people%20going%20to%20work%20at%20AI%20companies%20\(and/or%2C%20at%20Anthropic%20in%20particular\).)
+            on labs in general
+        papers:
+          - title: "The Alignment Waltz: Jointly Training Agents to Collaborate for Safety"
+            url: https://arxiv.org/pdf/2510.08240
+            authors: >-
+              Jingyu Zhang, Haozhu Wang, Eric Michael Smith, Sid Wang, Amr Sharaf, Mahesh Pasupuleti, Benjamin Van
+              Durme, Daniel Khashabi, Jason Weston, Hongyuan Zhan
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Co-improvement (PDF - content not accessible)
+            url: https://github.com/facebookresearch/RAM/blob/main/projects/co-improvement.pdf
+            year: 2025
+            venue: GitHub Repository
+            kind: error_detected
+          - title: Large Reasoning Models Learn Better Alignment from Flawed Thinking
+            url: https://arxiv.org/pdf/2510.00938%20
+            authors: >-
+              ShengYun Peng, Eric Smith, Ivan Evtimov, Song Jiang, Pin-Yu Chen, Hongyuan Zhan, Haozhu Wang, Duen Horng
+              Chau, Mahesh Pasupuleti, Jianfeng Chi
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Robust LLM safeguarding via refusal feature adversarial training
+            url: https://arxiv.org/pdf/2409.20089
+            authors: Lei Yu, Virginie Do, Karen Hambardzumyan, Nicola Cancedda
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: Code World Model Preparedness Report
+            url: >-
+              https://scontent-lhr8-1.xx.fbcdn.net/v/t39.2365-6/557601942_1468972530985309_838842257265552803_n.pdf?_nc_cat=108&ccb=1-7&_nc_sid=3c67a6&_nc_ohc=_H33_VKF3ZUQ7kNvwFog8dd&_nc_oc=AdlNtqCDY4HafZ3-d5rb26AF5f2m0X46SGdKhVq3jLqwpNf_wEXhdQnH7_30ychiZWk&_nc_zt=14&_nc_ht=scontent-lhr8-1.xx&_nc_gid=QvW_ePiaF4E-PxOf30MWyg&oh=00_AfiZC5G4ODvWhiy0MuVH8PSlUFrW8RDQQ8tdr6Zec5k9aA&oe=691A6D09
+          - title: "Connect 2024: The responsible approach we're taking to generative AI"
+            url: https://ai.meta.com/blog/practical-ai-agent-security/%20
+            year: 2024
+            venue: Meta AI Blog
+            kind: blog_post
+  - id: black_box
+    name: Black-box safety (understand and control current model behaviour)
     agendas:
       - id: unlearning
-        name: Unlearning
-        lesswrongTags:
-          - machine-unlearning
-        keywords:
-          - unlearning
-          - memorization
-          - tamper-resistance
-          - fine-tuning
-        papers:
-          - title: Modifying LLM Beliefs with Synthetic Document Finetuning
-            url: https://alignment.anthropic.com/2025/modifying-beliefs-via-sdf
-          - title: Distillation Robustifies Unlearning
-            url: https://arxiv.org/abs/2506.06278
-          - title: Layered Unlearning for Adversarial Relearning
-            url: https://arxiv.org/abs/2505.09500
-            authors: Timothy Qian, Vinith Suriyakumar, Ashia Wilson et al.
-          - title: "From Dormant to Deleted: Tamper-Resistant Unlearning Through Weight-Space Regularization"
-            url: https://arxiv.org/abs/2505.22310
-            authors: Shoaib Ahmed Siddiqui, Adrian Weller, David Krueger et al.
-          - title: "OpenUnlearning: Accelerating LLM Unlearning via Unified Benchmarking of Methods and Metrics"
-            url: https://arxiv.org/abs/2506.12618
-            authors: Vineeth Dorna, Anmol Mekala, Wenlong Zhao et al.
-          - title: "Machine Unlearning Doesn't Do What You Think: Lessons for Generative AI Policy and Research"
-            url: https://arxiv.org/abs/2412.06966
-            authors: A. Feder Cooper, Christopher A. Choquette-Choo, Miranda Bogen et al.
-          - title: Open Problems in Machine Unlearning for AI Safety
-            url: https://arxiv.org/abs/2501.04952
-            authors: Fazl Barez, Tingchen Fu, Ameya Prabhu et al.
-          - title: Understanding Memorization via Loss Curvature
-            url: https://goodfire.ai/research/understanding-memorization-via-loss-curvature
-            authors: Jack Merullo, Srihita Vatsavaya, Lucius Bushnaq et al.
-        summary: developing methods to selectively remove specific information, capabilities, or behaviors from a trained model without retraining it from scratch.
-        theoryOfChange: if an AI learns dangerous knowledge (e.g., dual-use capabilities) or exhibits undesirable behaviors (e.g., memorizing private data), we can specifically erase this “bad” knowledge post-training, which is much cheaper and faster than retraining, thereby making the model safer.
-        seeAlso: Mechanistic Interpretability, Red-teaming.
+        name: Capability removal, unlearning
+        summary: >-
+          Developing methods to selectively remove specific information, capabilities, or behaviors from a trained model
+          without retraining it from scratch. This is a mixture of black-box and white-box approaches.
+        theoryOfChange: >-
+          If an AI learns dangerous knowledge (e.g., dual-use capabilities) or exhibits undesirable behaviors (e.g.,
+          memorizing private data), we can specifically erase this "bad" knowledge post-training, which is much cheaper
+          and faster than retraining, thereby making the model safer.
+        seeAlso: sec:interpretability, a:various_redteams
         orthodoxProblems:
           - "1"
           - "4"
           - "10"
         targetCase: pessimistic
+        broadApproaches:
+          - cognitive
         someNames:
           - rowan-wang
           - avery-griffin
@@ -56,169 +544,290 @@ sections:
           - jing-li
           - timothy-qian
         estimatedFTEs: 10-50
-        fundedBy:
-          - open-philanthropy
-          - macarthur-foundation
-          - uk-aisi
-          - canadian-aisi
-          - microsoft-research
-          - google-deepmind
-        broadApproaches:
-          - cognitive
-        wikipedia: https://en.wikipedia.org/wiki/Machine_unlearning
-      - id: whitebox-unlearning
-        name: Whitebox unlearning
-        lesswrongTags:
-          - machine-unlearning
-        keywords:
-          - unlearning
-          - tamper-resistance
-          - features
-          - sparse-autoencoders
+        critiques:
+          - "[Existing Large Language Model Unlearning Evaluations Are Inconclusive](https://arxiv.org/abs/2506.00688)"
         papers:
+          - title: Modifying LLM Beliefs with Synthetic Document Finetuning
+            url: https://alignment.anthropic.com/2025/modifying-beliefs-via-sdf
+            authors: Rowan Wang, Avery Griffin, Johannes Treutlein, Ethan Perez, Julian Michael, Fabien Roger, Sam Marks
+            year: 2025
+            venue: Alignment Science Blog
+            kind: blog_post
+          - title: Distillation Robustifies Unlearning
+            url: https://arxiv.org/abs/2506.06278
+            authors: >-
+              Bruce W. Lee, Addie Foote, Alex Infanger, Leni Shor, Harish Kamath, Jacob Goldman-Wetzler, Bryce
+              Woodworth, Alex Cloud, Alexander Matt Turner
+            year: 2025
+            venue: arXiv (NeurIPS 2025 Spotlight)
+            kind: paper_preprint
+          - title: "From Dormant to Deleted: Tamper-Resistant Unlearning Through Weight-Space Regularization"
+            url: https://arxiv.org/abs/2505.22310
+            authors: >-
+              Shoaib Ahmed Siddiqui, Adrian Weller, David Krueger, Gintare Karolina Dziugaite, Michael Curtis Mozer,
+              Eleni Triantafillou
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "OpenUnlearning: Accelerating LLM Unlearning via Unified Benchmarking of Methods and Metrics"
+            url: https://arxiv.org/abs/2506.12618
+            authors: >-
+              Vineeth Dorna, Anmol Mekala, Wenlong Zhao, Andrew McCallum, Zachary C. Lipton, J. Zico Kolter, Pratyush
+              Maini
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Machine Unlearning Doesn't Do What You Think: Lessons for Generative AI Policy and Research"
+            url: https://arxiv.org/abs/2412.06966
+            authors: >-
+              A. Feder Cooper, Christopher A. Choquette-Choo, Miranda Bogen, Kevin Klyman, Matthew Jagielski, Katja
+              Filippova, Ken Liu, Alexandra Chouldechova, Jamie Hayes, Yangsibo Huang, Eleni Triantafillou, Peter
+              Kairouz, Nicole Elyse Mitchell, Niloofar Mireshghallah, Abigail Z. Jacobs, James Grimmelmann, Vitaly
+              Shmatikov, Christopher De Sa, Ilia Shumailov, Andreas Terzis, Solon Barocas, Jennifer Wortman Vaughan,
+              Danah Boyd, Yejin Choi, Sanmi Koyejo, Fernando Delgado, Percy Liang, Daniel E. Ho, Pamela Samuelson, Miles
+              Brundage, David Bau, Seth Neel, Hanna Wallach, Amy B. Cyphert, Mark A. Lemley, Nicolas Papernot, Katherine
+              Lee
+            year: 2024
+            venue: NeurIPS 2025 (Oral)
+            kind: paper_preprint
+          - title: Open Problems in Machine Unlearning for AI Safety
+            url: https://arxiv.org/abs/2501.04952
+            authors: >-
+              Fazl Barez, Tingchen Fu, Ameya Prabhu, Stephen Casper, Amartya Sanyal, Adel Bibi, Aidan O'Gara, Robert
+              Kirk, Ben Bucknall, Tim Fist, Luke Ong, Philip Torr, Kwok-Yan Lam, Robert Trager, David Krueger, Sören
+              Mindermann, José Hernandez-Orallo, Mor Geva, Yarin Gal
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Mirror Mirror on the Wall, Have I Forgotten it All? A New Framework for Evaluating Machine Unlearning
+            url: https://arxiv.org/abs/2505.08138
+            authors: Brennon Brimhall, Philip Mathew, Neil Fendley, Yinzhi Cao, Matthew Green
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
           - title: Safety Alignment via Constrained Knowledge Unlearning
             url: https://arxiv.org/abs/2505.18588
+            authors: Zesheng Shi, Yucheng Zhou, Jing Li
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
           - title: "Unlearning Isn't Deletion: Investigating Reversibility of Machine Unlearning in LLMs"
             url: https://arxiv.org/abs/2505.16831
-          - title: https://www.youtube.com/watch?v=pfKO4MlvM-Y
-            url: https://www.youtube.com/watch?v=pfKO4MlvM-Y
+            authors: Xiaoyu Xu, Xiang Yue, Yang Liu, Qingqing Ye, Huadi Zheng, Peizhao Hu, Minxin Du, Haibo Hu
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Understanding Memorization via Loss Curvature
+            url: https://goodfire.ai/research/understanding-memorization-via-loss-curvature
+            authors: Jack Merullo, Srihita Vatsavaya, Lucius Bushnaq, Owen Lewis
+            year: 2025
+            venue: Goodfire.ai Research Blog
+            kind: blog_post
+          - title: Unlearning Needs to be More Selective [Progress Report]
+            url: https://lesswrong.com/posts/QYzofMbzmbgiwfqy8/unlearning-needs-to-be-more-selective-progress-report
+            authors: Filip Sondej, Yushi Yang, Marcel Windys
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: Layered Unlearning for Adversarial Relearning
+            url: https://arxiv.org/abs/2505.09500
+            authors: Timothy Qian, Vinith Suriyakumar, Ashia Wilson, Dylan Hadfield-Menell
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Robust LLM Unlearning with MUDMAN: Meta-Unlearning with Disruption Masking And Normalization"
+            url: https://arxiv.org/abs/2506.12484
+            authors: Filip Sondej, Yushi Yang, Mikołaj Kniejski, Marcel Windys
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Collapse of Irrelevant Representations (CIR) Ensures Robust and Non-Disruptive LLM Unlearning
+            url: https://arxiv.org/abs/2509.11816
+            authors: Filip Sondej, Yushi Yang
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
       - id: control
         name: Control
-        lesswrongTags:
-          - ai-control
-        keywords:
-          - scheming
-          - safety-cases
-          - monitoring
-          - sabotage
-          - deception
-          - red-teaming
-          - evals
-          - model-organisms
-        papers:
-          - title: "Ctrl-Z: Controlling AI Agents via Resampling"
-            url: https://alignmentforum.org/posts/LPHMMMZFAWog6ty5x/ctrl-z-controlling-ai-agents-via-resampling
-            authors: Aryan Bhatt, Buck Shlegeris, Adam Kaufman et al.
-          - title: ControlArena
-            url: https://control-arena.aisi.org.uk/
-            authors: Rogan Inglis, Ollie Matthews, Tyler Tracy et al.
-          - title: https://openreview.net/forum?id=QWopGahUEL
-            url: https://openreview.net/forum?id=QWopGahUEL
-          - title: "SHADE-Arena: Evaluating Sabotage and Monitoring in LLM Agents"
-            url: https://arxiv.org/abs/2506.15740
-            authors: Jonathan Kutasov, Yuqi Sun, Paul Colognese et al.
-          - title: Adaptive Deployment of Untrusted LLMs Reduces Distributed Threats
-            url: https://arxiv.org/abs/2411.17693
-            authors: Jiaxin Wen, Vivek Hebbar, Caleb Larson et al.
-          - title: "D-REX: A Benchmark for Detecting Deceptive Reasoning in Large Language Models"
-            url: https://arxiv.org/abs/2509.17938
-            authors: Satyapriya Krishna, Andy Zou, Rahul Gupta et al.
-          - title: https://luthienresearch.org/updates/2025-03-redteam-as-upsampling/
-            url: https://luthienresearch.org/updates/2025-03-redteam-as-upsampling/
-          - title: Incentives for Responsiveness, Instrumental Control and Impact
-            url: https://arxiv.org/abs/2001.07118
-          - title: "Subversion Strategy Eval: Can language models statelessly strategize to subvert control protocols?"
-            url: https://arxiv.org/abs/2412.12480
-            authors: Alex Mallen, Charlie Griffin, Misha Wagner et al.
-          - title: Evaluating Control Protocols for Untrusted AI Agents
-            url: https://arxiv.org/abs/2511.02997
-            authors: Jon Kutasov, Chloe Loughridge, Yuqi Sun et al.
-          - title: Can Reasoning Models Obfuscate Reasoning? Stress-Testing Chain-of-Thought Monitorability
-            url: https://arxiv.org/abs/2510.19851
-            authors: Artur Zolkowski, Wen Xing, David Lindner et al.
-          - title: Optimizing AI Agent Attacks With Synthetic Data
-            url: https://arxiv.org/abs/2511.02823
-            authors: Chloe Loughridge, Paul Colognese, Avery Griffin et al.
-          - title: A sketch of an AI control safety case
-            url: https://arxiv.org/abs/2501.17315
-            authors: Tomek Korbak, Joshua Clymer, Benjamin Hilton et al.
-          - title: Assessing confidence in frontier AI safety cases
-            url: https://arxiv.org/abs/2502.05791
-            authors: Stephen Barrett, Philip Fox, Joshua Krook et al.
-          - title: How to evaluate control measures for LLM agents? A trajectory from today to superintelligence
-            url: https://arxiv.org/abs/2504.05259
-            authors: Tomek Korbak, Mikita Balesni, Buck Shlegeris et al.
-          - title: Towards evaluations-based safety cases for AI scheming
-            url: https://arxiv.org/abs/2411.03336
-            authors: Mikita Balesni, Marius Hobbhahn, David Lindner et al.
-          - title: Putting up Bumpers
-            url: https://alignment.anthropic.com/2025/bumpers
-          - title: "Manipulation Attacks by Misaligned AI: Risk Analysis and Safety Case Framework"
-            url: https://arxiv.org/abs/2507.12872
-            authors: Rishane Dassanayake, Mario Demetroudi, James Walpole et al.
-          - title: Dynamic safety cases for frontier AI
-            url: https://arxiv.org/abs/2412.17618
-            authors: Carmen Cârlan, Francesca Gomez, Yohan Mathew et al.
-          - title: The Alignment Project by UK AISI
-            url: https://lesswrong.com/posts/wKTwdgZDo479EhmJL/the-alignment-project-by-uk-aisi-1
-            authors: Mojmir, Benjamin Hilton, Jacob Pfau et al.
-          - title: AI companies are unlikely to make high-assurance safety cases if timelines are short
-            url: https://lesswrong.com/posts/neTbrpBziAsTH5Bn7/ai-companies-are-unlikely-to-make-high-assurance-safety
-            authors: Ryan Greenblatt
-          - title: AIs at the current capability level may be important for future safety work
-            url: https://lesswrong.com/posts/cJQZAueoPC6aTncKK/ais-at-the-current-capability-level-may-be-important-for
-            authors: Ryan Greenblatt
-          - title: Takeaways from sketching a control safety case
-            url: https://lesswrong.com/posts/y6rBarAPTLmuhn9PJ/takeaways-from-sketching-a-control-safety-case
-            authors: Josh Clymer, Buck Shlegeris
-          - title: https://openai.com/index/introducing-agentkit/
-            url: https://openai.com/index/introducing-agentkit/
-        summary: assuming early transformative AIs are misaligned and actively trying to subvert safety measures, can we still set up protocols to extract useful work from them?
-        theoryOfChange: ""
+        summary: >-
+          Assuming early transformative AIs are misaligned and actively trying to subvert safety measures, can we still
+          set up protocols to extract useful work from them?
         seeAlso: safety cases
-        targetCase: "*worst-case*"
+        targetCase: worst-case
         someNames:
-          - "*Redwood"
+          - redwood
           - uk-aisi
           - buck-shlegeris
           - ryan-greenblatt
           - kshitij-sachan
           - alex-mallen
-        estimatedFTEs: "*(SR2024: 9\\)*"
+        estimatedFTEs: 5-50
         critiques:
-          - "[Wentworth](https://www.lesswrong.com/posts/8wBN8cdNAv3c7vt6p/the-case-against-ai-control-research)"
-          - "[Mannheim](https://lesswrong.com/posts/25dsPH6CuRXPBkGHN/no-we-re-not-getting-meaningful-oversight-of-ai)"
+          - >-
+            [Wentworth](https://www.lesswrong.com/posts/8wBN8cdNAv3c7vt6p/the-case-against-ai-control-research),
+            [Mannheim](https://lesswrong.com/posts/25dsPH6CuRXPBkGHN/no-we-re-not-getting-meaningful-oversight-of-ai),
+            [Kulveit](https://www.lesswrong.com/posts/rZcyemEpBHgb2hqLP/ai-control-may-increase-existential-risk)
+        papers:
+          - title: "Ctrl-Z: Controlling AI Agents via Resampling"
+            url: https://alignmentforum.org/posts/LPHMMMZFAWog6ty5x/ctrl-z-controlling-ai-agents-via-resampling
+            authors: >-
+              Aryan Bhatt, Buck Shlegeris, Adam Kaufman, Cody Rushing, Tyler Tracy, Vasil Georgiev, David Matolcsi,
+              Akbir Khan
+            year: 2025
+            venue: AI Alignment Forum
+            kind: lesswrong
+          - title: ControlArena
+            url: https://control-arena.aisi.org.uk/
+            authors: >-
+              Rogan Inglis, Ollie Matthews, Tyler Tracy, Oliver Makins, Tom Catling, Asa Cooper Stickland, Rasmus
+              Faber-Espensen, Daniel O'Connell, Myles Heller, Miguel Brandao, Adam Hanson, Arathi Mani, Tomek Korbak,
+              Jan Michelfeit, Dishank Bansal, Tomas Bark, Chris Canal, Charlie Griffin, Jasmine Wang, Alan Cooney
+            year: 2025
+            venue: GitHub
+            kind: code_tool
+          - title: "Games for AI Control: Models of Safety Evaluations of AI Deployment Protocols"
+            url: https://openreview.net/forum?id=QWopGahUEL
+            authors: Charlie Griffin, Louis Thomson, Buck Shlegeris, Alessandro Abate
+            year: 2025
+            venue: ICLR 2026 Conference (Withdrawn)
+            kind: paper_preprint
+          - title: "SHADE-Arena: Evaluating Sabotage and Monitoring in LLM Agents"
+            url: https://arxiv.org/abs/2506.15740
+            authors: >-
+              Jonathan Kutasov, Yuqi Sun, Paul Colognese, Teun van der Weij, Linda Petrini, Chen Bo Calvin Zhang, John
+              Hughes, Xiang Deng, Henry Sleight, Tyler Tracy, Buck Shlegeris, Joe Benton
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Adaptive Deployment of Untrusted LLMs Reduces Distributed Threats
+            url: https://arxiv.org/abs/2411.17693
+            authors: >-
+              Jiaxin Wen, Vivek Hebbar, Caleb Larson, Aryan Bhatt, Ansh Radhakrishnan, Mrinank Sharma, Henry Sleight,
+              Shi Feng, He He, Ethan Perez, Buck Shlegeris, Akbir Khan
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: "D-REX: A Benchmark for Detecting Deceptive Reasoning in Large Language Models"
+            url: https://arxiv.org/abs/2509.17938
+            authors: >-
+              Satyapriya Krishna, Andy Zou, Rahul Gupta, Eliot Krzysztof Jones, Nick Winter, Dan Hendrycks, J. Zico
+              Kolter, Matt Fredrikson, Spyros Matsoukas
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: https://luthienresearch.org/updates/2025-03-redteam-as-upsampling/
+            url: https://luthienresearch.org/updates/2025-03-redteam-as-upsampling/
+          - title: Incentives for Responsiveness, Instrumental Control and Impact
+            url: https://arxiv.org/abs/2001.07118
+            authors: Ryan Carey, Eric Langlois, Chris van Merwijk, Shane Legg, Tom Everitt
+            year: 2020
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Subversion Strategy Eval: Can language models statelessly strategize to subvert control protocols?"
+            url: https://arxiv.org/abs/2412.12480
+            authors: Alex Mallen, Charlie Griffin, Misha Wagner, Alessandro Abate, Buck Shlegeris
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: Evaluating Control Protocols for Untrusted AI Agents
+            url: https://arxiv.org/abs/2511.02997
+            authors: Jon Kutasov, Chloe Loughridge, Yuqi Sun, Henry Sleight, Buck Shlegeris, Tyler Tracy, Joe Benton
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Can Reasoning Models Obfuscate Reasoning? Stress-Testing Chain-of-Thought Monitorability
+            url: https://arxiv.org/abs/2510.19851
+            authors: Artur Zolkowski, Wen Xing, David Lindner, Florian Tramèr, Erik Jenner
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Optimizing AI Agent Attacks With Synthetic Data
+            url: https://arxiv.org/abs/2511.02823
+            authors: Chloe Loughridge, Paul Colognese, Avery Griffin, Tyler Tracy, Jon Kutasov, Joe Benton
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: A sketch of an AI control safety case
+            url: https://arxiv.org/abs/2501.17315
+            authors: Tomek Korbak, Joshua Clymer, Benjamin Hilton, Buck Shlegeris, Geoffrey Irving
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Assessing confidence in frontier AI safety cases
+            url: https://arxiv.org/abs/2502.05791
+            authors: Stephen Barrett, Philip Fox, Joshua Krook, Tuneer Mondal, Simon Mylius, Alejandro Tlaie
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: How to evaluate control measures for LLM agents? A trajectory from today to superintelligence
+            url: https://arxiv.org/abs/2504.05259
+            authors: Tomek Korbak, Mikita Balesni, Buck Shlegeris, Geoffrey Irving
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Towards evaluations-based safety cases for AI scheming
+            url: https://arxiv.org/abs/2411.03336
+            authors: >-
+              Mikita Balesni, Marius Hobbhahn, David Lindner, Alexander Meinke, Tomek Korbak, Joshua Clymer, Buck
+              Shlegeris, Jérémy Scheurer, Charlotte Stix, Rusheb Shah, Nicholas Goldowsky-Dill, Dan Braun, Bilal
+              Chughtai, Owain Evans, Daniel Kokotajlo, Lucius Bushnaq
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: Putting up Bumpers
+            url: https://alignment.anthropic.com/2025/bumpers
+            year: 2025
+            venue: Anthropic Alignment Science Blog
+            kind: blog_post
+          - title: "Manipulation Attacks by Misaligned AI: Risk Analysis and Safety Case Framework"
+            url: https://arxiv.org/abs/2507.12872
+            authors: Rishane Dassanayake, Mario Demetroudi, James Walpole, Lindley Lentati, Jason R. Brown, Edward James Young
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Dynamic safety cases for frontier AI
+            url: https://arxiv.org/abs/2412.17618
+            authors: Carmen Cârlan, Francesca Gomez, Yohan Mathew, Ketana Krishna, René King, Peter Gebauer, Ben R. Smith
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: The Alignment Project by UK AISI
+            url: https://lesswrong.com/posts/wKTwdgZDo479EhmJL/the-alignment-project-by-uk-aisi-1
+            authors: Mojmir, Benjamin Hilton, Jacob Pfau, Geoffrey Irving, Joseph Bloom, Tomek Korbak, David Africa, Edmund Lau
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: AI companies are unlikely to make high-assurance safety cases if timelines are short
+            url: https://lesswrong.com/posts/neTbrpBziAsTH5Bn7/ai-companies-are-unlikely-to-make-high-assurance-safety
+            authors: Ryan Greenblatt
+            year: 2025
+            venue: LessWrong / AI Alignment Forum
+            kind: lesswrong
+          - title: AIs at the current capability level may be important for future safety work
+            url: https://lesswrong.com/posts/cJQZAueoPC6aTncKK/ais-at-the-current-capability-level-may-be-important-for
+            authors: Ryan Greenblatt
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: Takeaways from sketching a control safety case
+            url: https://lesswrong.com/posts/y6rBarAPTLmuhn9PJ/takeaways-from-sketching-a-control-safety-case
+            authors: Josh Clymer, Buck Shlegeris
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+      - id: anthropic_safeguards
+        name: Safeguards (inference-time auxiliaries)
+        summary: >-
+          Layers of inference-time defenses, such as classifiers, monitors, and rapid-response protocols, to detect and
+          block jailbreaks, prompt injections, and other harmful model behaviors.
+        theoryOfChange: >-
+          By building a bunch of scalable and hardened things on top of an unsafe model, we can defend against known and
+          unknown attacks, monitor for misuse, and prevent models from causing harm, even if the core model has
+          vulnerabilities.
+        seeAlso: a:various_redteams, sec:iterative_alignment
+        targetCase: average-case
         broadApproaches:
           - engineering
-          - behavioral
-        resources:
-          - title: Redwood Research
-            url: https://www.redwoodresearch.org/
-          - title: "AI Control: Improving Safety Despite Intentional Subversion"
-            url: https://arxiv.org/abs/2312.06942
-      - id: safeguards-inference-time-auxiliaries
-        name: Safeguards (inference-time auxiliaries)
-        keywords:
-          - jailbreaking
-          - prompt-injection
-          - classifiers
-          - monitoring
-          - red-teaming
-        papers:
-          - title: "Constitutional Classifiers: Defending against Universal Jailbreaks across Thousands of Hours of Red Teaming"
-            url: https://arxiv.org/abs/2501.18837
-            authors: Mrinank Sharma, Meg Tong, Jesse Mu et al.
-          - title: "Rapid Response: Mitigating LLM Jailbreaks with a Few Examples"
-            url: https://arxiv.org/abs/2411.07494
-            authors: Alwin Peng, Julian Michael, Henry Sleight et al.
-          - title: Monitoring computer use via hierarchical summarization
-            url: https://alignment.anthropic.com/2025/summarization-for-monitoring/index.html
-            authors: Theodore Sumers, Raj Agarwal, Nathan Bailey et al.
-          - title: Defeating Prompt Injections by Design
-            url: https://arxiv.org/abs/2503.18813
-            authors: Edoardo Debenedetti, Ilia Shumailov, Tianqi Fan et al.
-          - title: Introducing Anthropic's Safeguards Research Team
-            url: https://alignment.anthropic.com/2025/introducing-safeguards-research-team/index.html
-          - title: "OMNIGUARD: An Efficient Approach for AI Safety Moderation Across Modalities"
-            url: https://arxiv.org/abs/2505.23856
-            authors: Sahil Verma, Keegan Hines, Jeff Bilmes et al.
-        summary: layers of inference-time defenses, such as classifiers, monitors, and rapid-response protocols, to detect and block jailbreaks, prompt injections, and other harmful model behaviors.
-        theoryOfChange: By building a bunch of scalable and hardened things on top of an unsafe model, we can defend against known and unknown attacks, monitor for misuse, and prevent models from causing harm, even if the core model has vulnerabilities.
-        seeAlso: various redteams, iterative alignment.
-        orthodoxProblems:
-          - "7"
-          - "12"
-        targetCase: optimistic
         someNames:
           - mrinank-sharma
           - meg-tong
@@ -237,68 +846,73 @@ sections:
           - jeff-bilmes
         estimatedFTEs: 100+
         critiques:
-          - "[Obfuscated Activations Bypass LLM Latent-Space Defenses](https://arxiv.org/abs/2412.09565)"
+          - "[Obfuscated Activations Bypass LLM Latent-Space Defenses](https://arxiv.org/abs/2412.09565)."
+        papers:
+          - title: >-
+              Constitutional Classifiers: Defending against Universal Jailbreaks across Thousands of Hours of Red
+              Teaming
+            url: https://arxiv.org/abs/2501.18837
+            authors: >-
+              Mrinank Sharma, Meg Tong, Jesse Mu, Jerry Wei, Jorrit Kruthoff, Scott Goodfriend, Euan Ong, Alwin Peng,
+              Raj Agarwal, Cem Anil, Amanda Askell, Nathan Bailey, Joe Benton, Emma Bluemke, Samuel R. Bowman, Eric
+              Christiansen, Hoagy Cunningham, Andy Dau, Anjali Gopal, Rob Gilson, Logan Graham, Logan Howard, Nimit
+              Kalra, Taesung Lee, Kevin Lin, Peter Lofgren, Francesco Mosconi, Clare O'Hara, Catherine Olsson, Linda
+              Petrini, Samir Rajani, Nikhil Saxena, Alex Silverstein, Tanya Singh, Theodore Sumers, Leonard Tang, Kevin
+              K. Troy, Constantin Weisser, Ruiqi Zhong, Giulio Zhou, Jan Leike, Jared Kaplan, Ethan Perez
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Rapid Response: Mitigating LLM Jailbreaks with a Few Examples"
+            url: https://arxiv.org/abs/2411.07494
+            authors: Alwin Peng, Julian Michael, Henry Sleight, Ethan Perez, Mrinank Sharma
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: Monitoring computer use via hierarchical summarization
+            url: https://alignment.anthropic.com/2025/summarization-for-monitoring/index.html
+            authors: >-
+              Theodore Sumers, Raj Agarwal, Nathan Bailey, Tim Belonax, Brian Clarke, Jasmine Deng, Kyla Guru, Evan
+              Frondorf, Keegan Hankes, Jacob Klein, Lynx Lean, Kevin Lin, Linda Petrini, Madeleine Tucker, Ethan Perez,
+              Mrinank Sharma, Nikhil Saxena
+            year: 2025
+            venue: Anthropic Alignment Science Blog
+            kind: blog_post
+          - title: Defeating Prompt Injections by Design
+            url: https://arxiv.org/abs/2503.18813
+            authors: >-
+              Edoardo Debenedetti, Ilia Shumailov, Tianqi Fan, Jamie Hayes, Nicholas Carlini, Daniel Fabian, Christoph
+              Kern, Chongyang Shi, Andreas Terzis, Florian Tramèr
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Introducing Anthropic's Safeguards Research Team
+            url: https://alignment.anthropic.com/2025/introducing-safeguards-research-team/index.html
+            year: 2025
+            venue: Anthropic Alignment Science Blog
+            kind: news_announcement
+          - title: "OMNIGUARD: An Efficient Approach for AI Safety Moderation Across Modalities"
+            url: https://arxiv.org/abs/2505.23856
+            authors: Sahil Verma, Keegan Hines, Jeff Bilmes, Charlotte Siska, Luke Zettlemoyer, Hila Gonen, Chandan Singh
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+      - id: cot_monitoring
+        name: Chain of thought monitoring
+        summary: >-
+          Supervise an AI's natural-language (output) "reasoning" to detect misalignment, scheming, or deception, rather
+          than studying the actual internal states.
+        theoryOfChange: >-
+          The reasoning process (Chain of Thought, or CoT) of an AI provides a legible signal of its internal state and
+          intentions. By monitoring this CoT, supervisors (human or AI) can detect misalignment, scheming, or reward
+          hacking before it results in a harmful final output. This allows for more robust oversight than supervising
+          outputs alone, but it relies on the CoT remaining faithful (i.e., accurately reflecting the model's reasoning)
+          and not becoming obfuscated under optimization pressure.
+        seeAlso: sec:whitebox, a:evals_steganography
+        targetCase: average-case
         broadApproaches:
           - engineering
-      - id: chain-of-thought-monitoring
-        name: Chain of thought monitoring
-        lesswrongTags:
-          - chain-of-thought-alignment
-        keywords:
-          - faithfulness
-          - obfuscation
-          - monitoring
-          - reward-hacking
-          - deception
-          - scheming
-        papers:
-          - title: "Chain of Thought Monitorability: A New and Fragile Opportunity for AI Safety"
-            url: https://arxiv.org/abs/2507.11473
-            authors: Tomek Korbak, Mikita Balesni, Elizabeth Barnes et al.
-          - title: Detecting misbehavior in frontier reasoning models
-            url: https://openai.com/index/chain-of-thought-monitoring/
-            authors: Bowen Baker, Joost Huizinga, Aleksander Madry et al.
-          - title: Training fails to elicit subtle reasoning in current language models
-            url: https://alignment.anthropic.com/2025/subtle-reasoning/
-          - title: Are DeepSeek R1 And Other Reasoning Models More Faithful?
-            url: https://arxiv.org/abs/2501.08156
-            authors: James Chua, Owain Evans
-          - title: Can Reasoning Models Obfuscate Reasoning? Stress-Testing Chain-of-Thought Monitorability
-            url: https://arxiv.org/abs/2510.19851
-          - title: Monitoring Reasoning Models for Misbehavior and the Risks of Promoting Obfuscation
-            url: https://arxiv.org/abs/2503.11926
-            authors: Bowen Baker, Joost Huizinga, Leo Gao et al.
-          - title: When Chain of Thought is Necessary, Language Models Struggle to Evade Monitors
-            url: https://arxiv.org/abs/2507.05246
-            authors: Scott Emmons, Erik Jenner, David K. Elson et al.
-          - title: Reasoning Models Don't Always Say What They Think
-            url: https://arxiv.org/abs/2505.05410
-            authors: Yanda Chen, Joe Benton, Ansh Radhakrishnan et al.
-          - title: Is It Thinking or Cheating? Detecting Implicit Reward Hacking by Measuring Reasoning Effort
-            url: https://arxiv.org/abs/2510.01367
-            authors: Xinpeng Wang, Nitish Joshi, Barbara Plank et al.
-          - title: Teaching Models to Verbalize Reward Hacking in Chain-of-Thought Reasoning
-            url: https://arxiv.org/abs/2506.22777
-            authors: Miles Turpin, Andy Arditi, Marvin Li et al.
-          - title: A Pragmatic Way to Measure Chain-of-Thought Monitorability
-            url: https://arxiv.org/abs/2510.23966
-            authors: Scott Emmons, Roland S. Zimmermann, David K. Elson et al.
-          - title: https://www.lesswrong.com/posts/B8Cmtf5gdHwxb8qtT/aether-july-2025-update
-            url: https://www.lesswrong.com/posts/B8Cmtf5gdHwxb8qtT/aether-july-2025-update
-          - title: A Concrete Roadmap towards Safety Cases based on Chain-of-Thought Monitoring
-            url: https://lesswrong.com/posts/Em9sihEZmbofZKc2t/a-concrete-roadmap-towards-safety-cases-based-on-chain-of
-            authors: Wuschel Schulz
-          - title: "CoT Red-Handed: Stress Testing Chain-of-Thought Monitoring"
-            url: https://arxiv.org/abs/2505.23575
-        summary: supervise an AI's step-by-step reasoning process to detect misalignment, scheming, or deception, rather than only checking its final answer.
-        theoryOfChange: the reasoning process (Chain of Thought, or CoT) of an AI provides a legible signal of its internal state and intentions. By monitoring this CoT, supervisors (human or AI) can detect misalignment, scheming, or reward hacking before it results in a harmful final output. This allows for more robust oversight than supervising outputs alone, but it relies on the CoT remaining faithful (i.e., accurately reflecting the model's reasoning) and not becoming obfuscated under optimization pressure.
-        seeAlso: whitebox control / monitoring, steganography evals, [Why Don't We Just... Shoggoth+Face+Paraphraser?](https://www.lesswrong.com/posts/Tzdwetw55JNqFTkzK/why-don-t-we-just-shoggoth-face-paraphraser)**,** [Why it’s good for AI reasoning to be legible and faithful.](https://metr.org/blog/2025-03-11-good-for-ai-to-reason-legibly-and-faithfully/)
-        orthodoxProblems:
-          - "7"
-          - "8"
-          - "12"
-        targetCase: average case
         someNames:
+          - aether
           - bowen-baker
           - joost-huizinga
           - leo-gao
@@ -312,84 +926,708 @@ sections:
           - xinpeng-wang
           - miles-turpin
         estimatedFTEs: 10-100
-        fundedBy:
-          - openai
-          - anthropic
-          - google-deepmind
+        critiques:
+          - >-
+            [Reasoning Models Don't Always Say What They
+            Think](https://assets.anthropic.com/m/71876fabef0f0ed4/original/reasoning_models_paper.pdf);
+            [Chain-of-Thought Reasoning In The Wild Is Not Always Faithful](https://arxiv.org/abs/2503.08679); [Beyond
+            Semantics: The Unreasonable Effectiveness of Reasonless Intermediate
+            Tokens](https://arxiv.org/abs/2505.13775); [Reasoning Models Sometimes Output Illegible Chains of
+            Thought](https://arxiv.org/abs/2510.27338)
+        papers:
+          - title: "Chain of Thought Monitorability: A New and Fragile Opportunity for AI Safety"
+            url: https://arxiv.org/abs/2507.11473
+            authors: >-
+              Tomek Korbak, Mikita Balesni, Elizabeth Barnes, Yoshua Bengio, Joe Benton, Joseph Bloom, Mark Chen, Alan
+              Cooney, Allan Dafoe, Anca Dragan, Scott Emmons, Owain Evans, David Farhi, Ryan Greenblatt, Dan Hendrycks,
+              Marius Hobbhahn, Evan Hubinger, Geoffrey Irving, Erik Jenner, Daniel Kokotajlo, Victoria Krakovna, Shane
+              Legg, David Lindner, David Luan, Aleksander Mądry, Julian Michael, Neel Nanda, Dave Orr, Jakub Pachocki,
+              Ethan Perez, Mary Phuong, Fabien Roger, Joshua Saxe, Buck Shlegeris, Martín Soto, Eric Steinberger,
+              Jasmine Wang, Wojciech Zaremba, Bowen Baker, Rohin Shah, Vlad Mikulik
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Detecting misbehavior in frontier reasoning models
+            url: https://openai.com/index/chain-of-thought-monitoring/
+            authors: Bowen Baker, Joost Huizinga, Aleksander Madry, Wojciech Zaremba, Jakub Pachocki, David Farhi
+            year: 2025
+            venue: OpenAI Blog / arXiv
+            kind: blog_post
+          - title: Training fails to elicit subtle reasoning in current language models
+            url: https://alignment.anthropic.com/2025/subtle-reasoning/
+            year: 2025
+            venue: Alignment Science Blog
+            kind: blog_post
+          - title: Are DeepSeek R1 And Other Reasoning Models More Faithful?
+            url: https://arxiv.org/abs/2501.08156
+            authors: James Chua, Owain Evans
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Can Reasoning Models Obfuscate Reasoning? Stress-Testing Chain-of-Thought Monitorability
+            url: https://arxiv.org/abs/2510.19851
+            authors: Artur Zolkowski, Wen Xing, David Lindner, Florian Tramèr, Erik Jenner
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Monitoring Reasoning Models for Misbehavior and the Risks of Promoting Obfuscation
+            url: https://arxiv.org/abs/2503.11926
+            authors: >-
+              Bowen Baker, Joost Huizinga, Leo Gao, Zehao Dou, Melody Y. Guan, Aleksander Madry, Wojciech Zaremba, Jakub
+              Pachocki, David Farhi
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: When Chain of Thought is Necessary, Language Models Struggle to Evade Monitors
+            url: https://arxiv.org/abs/2507.05246
+            authors: >-
+              Scott Emmons, Erik Jenner, David K. Elson, Rif A. Saurous, Senthooran Rajamanoharan, Heng Chen, Irhum
+              Shafkat, Rohin Shah
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Reasoning Models Don't Always Say What They Think
+            url: https://arxiv.org/abs/2505.05410
+            authors: >-
+              Yanda Chen, Joe Benton, Ansh Radhakrishnan, Jonathan Uesato, Carson Denison, John Schulman, Arushi Somani,
+              Peter Hase, Misha Wagner, Fabien Roger, Vlad Mikulik, Samuel R. Bowman, Jan Leike, Jared Kaplan, Ethan
+              Perez
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Is It Thinking or Cheating? Detecting Implicit Reward Hacking by Measuring Reasoning Effort
+            url: https://arxiv.org/abs/2510.01367
+            authors: Xinpeng Wang, Nitish Joshi, Barbara Plank, Rico Angell, He He
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Teaching Models to Verbalize Reward Hacking in Chain-of-Thought Reasoning
+            url: https://arxiv.org/abs/2506.22777
+            authors: Miles Turpin, Andy Arditi, Marvin Li, Joe Benton, Julian Michael
+            year: 2025
+            venue: ICML 2025 Workshop on Reliable and Responsible Foundation Models
+            kind: paper_preprint
+          - title: A Pragmatic Way to Measure Chain-of-Thought Monitorability
+            url: https://arxiv.org/abs/2510.23966
+            authors: Scott Emmons, Roland S. Zimmermann, David K. Elson, Rohin Shah
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Aether July 2025 Update
+            url: https://www.lesswrong.com/posts/B8Cmtf5gdHwxb8qtT/aether-july-2025-update
+            authors: Rohan Subramani, Rauno Arike, Shubhorup Biswas
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: A Concrete Roadmap towards Safety Cases based on Chain-of-Thought Monitoring
+            url: https://lesswrong.com/posts/Em9sihEZmbofZKc2t/a-concrete-roadmap-towards-safety-cases-based-on-chain-of
+            authors: Wuschel Schulz
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "CoT Red-Handed: Stress Testing Chain-of-Thought Monitoring"
+            url: https://arxiv.org/abs/2505.23575
+            authors: Benjamin Arnav, Pablo Bernabeu-Pérez, Nathan Helm-Burger, Tim Kostolansky, Hannes Whittingham, Mary Phuong
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Why don't we just shoggoth-face paraphraser
+            url: https://www.lesswrong.com/posts/Tzdwetw55JNqFTkzK/why-don-t-we-just-shoggoth-face-paraphraser
+            venue: LessWrong
+            kind: error_detected
+          - title: Why it's good for AI reasoning to be legible and faithful
+            url: https://metr.org/blog/2025-03-11-good-for-ai-to-reason-legibly-and-faithfully/
+            year: 2025
+            venue: METR Blog
+            kind: blog_post
+      - id: data_poisoning
+        name: Data poisoning defense
+        summary: >-
+          Develops methods to detect and prevent malicious or backdoor-inducing samples from being included in the
+          training data.
+        theoryOfChange: >-
+          By identifying and filtering out malicious training examples, we can prevent attackers from creating hidden
+          backdoors or triggers that would cause aligned models to behave dangerously.
+        seeAlso: a:data_filtering, a:anthropic_safeguards, a:various_redteams, adversarial robustness
+        targetCase: pessimistic
         broadApproaches:
           - engineering
-      - id: emergent-misalignment
-        name: Emergent misalignment
-        lesswrongTags:
-          - deceptive-alignment
-        keywords:
-          - fine-tuning
-          - reward-hacking
-          - shutdown-resistance
-          - deception
-          - personas
-          - goal-misgeneralization
+        someNames:
+          - alexandra-souly
+          - javier-rando
+          - ed-chapman
+          - hanna-foerster
+          - ilia-shumailov
+          - yiren-zhao
+        estimatedFTEs: 5-20
+        critiques:
+          - >-
+            [A small number of samples can poison LLMs of any size](https://arxiv.org/abs/2510.04567), [Reasoning
+            Introduces New Poisoning Attacks Yet Makes Them More Complicated](https://arxiv.org/abs/2509.03405)
         papers:
-          - title: "Emergent Misalignment: Narrow finetuning can produce broadly misaligned LLMs"
-            url: https://arxiv.org/abs/2502.17424
-            authors: Jan Betley, Daniel Tan, Niels Warncke et al.
-          - title: "Thought Crime: Backdoors and Emergent Misalignment in Reasoning Models"
-            url: https://arxiv.org/abs/2506.13206
-            authors: James Chua, Jan Betley, Mia Taylor et al.
-          - title: Persona Features Control Emergent Misalignment
-            url: https://arxiv.org/abs/2506.19823
-            authors: Miles Wang, Tom Dupré la Tour, Olivia Watkins et al.
-          - title: Model Organisms for Emergent Misalignment
-            url: https://arxiv.org/abs/2506.11613
-            authors: Edward Turner, Anna Soligo, Mia Taylor et al.
-          - title: "School of Reward Hacks: Hacking harmless tasks generalizes to misaligned behavior in LLMs"
-            url: https://arxiv.org/abs/2508.17511
-            authors: Mia Taylor, James Chua, Jan Betley et al.
-          - title: "Subliminal Learning: Language Models Transmit Behavioral Traits via Hidden Signals in Data"
-            url: https://alignment.anthropic.com/2025/subliminal-learning/
-            authors: Alex Cloud, Minh Le, James Chua et al.
-          - title: Narrow Misalignment is Hard, Emergent Misalignment is Easy
-            url: https://www.lesswrong.com/posts/gLDSqQm8pwNiq7qst/narrow-misalignment-is-hard-emergent-misalignment-is-easy
-            authors: Edward Turner, Anna Soligo, Senthooran Rajamanoharan et al.
-          - title: Realistic Reward Hacking Induces Different and Deeper Misalignment
-            url: https://www.lesswrong.com/posts/HLJoJYi52mxgomujc/realistic-reward-hacking-induces-different-and-deeper-1
-            authors: Jozdien
-          - title: The Rise of Parasitic AI
-            url: https://www.lesswrong.com/posts/6ZnznCaTcbGYsCmqu/the-rise-of-parasitic-ai
-            authors: Adele Lopez
-          - title: Convergent Linear Representations of Emergent Misalignment
-            url: https://lesswrong.com/posts/umYzsh7SGHHKsRCaA/convergent-linear-representations-of-emergent-misalignment
-            authors: Anna Soligo, Edward Turner, Senthooran Rajamanoharan et al.
-          - title: Aesthetic Preferences Can Cause Emergent Misalignment
-            url: https://lesswrong.com/posts/gT3wtWBAs7PKonbmy/aesthetic-preferences-can-cause-emergent-misalignment
-            authors: Anders Woodruff
-          - title: Emergent Misalignment & Realignment
-            url: https://lesswrong.com/posts/ZdY4JzBPJEgaoCxTR/emergent-misalignment-and-realignment
-            authors: Elizaveta Tennant, Jasper Timm, Kevin Wei et al.
-          - title: "Selective Generalization: Improving Capabilities While Maintaining Alignment"
-            url: https://lesswrong.com/posts/ZXxY2tccLapdjLbKm/selective-generalization-improving-capabilities-while
-            authors: Ariana Azarbal, Matthew A. Clarke, Jorio Cocola et al.
-          - title: "Go home GPT-4o, you're drunk: emergent misalignment as lowered inhibitions"
-            url: https://lesswrong.com/posts/RoWabfQxabWBiXwxP/go-home-gpt-4o-you-re-drunk-emergent-misalignment-as-lowered
-            authors: Stuart_Armstrong, rgorman
-          - title: Emergent Misalignment on a Budget
-            url: https://lesswrong.com/posts/qHudHZNLCiFrygRiy/emergent-misalignment-on-a-budget
-            authors: Valerio Pepe, Armaan Tipirneni
-          - title: LLM AGI may reason about its goals and discover misalignments by default
-            url: https://lesswrong.com/posts/4XdxiqBsLKqiJ9xRM/llm-agi-may-reason-about-its-goals-and-discover
-            authors: Seth Herd
-          - title: Open problems in emergent misalignment
-            url: https://lesswrong.com/posts/AcTEiu5wYDgrbmXow/open-problems-in-emergent-misalignment
-            authors: Jan Betley, Daniel Tan
-          - title: The Claude System Prompt by words allocated
-            url: https://www.oreilly.com/radar/unpacking-claudes-system-prompt/
-        summary: fine-tuning LLMs on one narrow antisocial task can cause *general* misalignment including deception, shutdown resistance, harmful advice, and extremist sympathies, when those behaviors are never trained or rewarded directly. [A new agenda](https://www.lesswrong.com/posts/AcTEiu5wYDgrbmXow/open-problems-in-emergent-misalignment) which quickly led to a stream of exciting work.
-        theoryOfChange: predict, detect, and prevent models from developing broadly harmful behaviors (like deception or shutdown resistance) when fine-tuned on seemingly unrelated tasks. Find, preserve, and robustify this correlated representation of the good.
-        seeAlso: auditing real models, applied interpretability.
+          - title: A small number of samples can poison LLMs of any size
+            url: https://example-blog.com/a-small-number-of-samples-can-poison-llms
+          - title: "GILT: An LLM-Free, Tuning-Free Graph Foundational Model for In-Context Learning"
+            url: https://arxiv.org/abs/2510.04567
+            authors: Weishuo Ma, Yanbo Wang, Xiyuan Wang, Lei Zou, Muhan Zhang
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "LMEnt: A Suite for Analyzing Knowledge in Language Models from Pretraining Data to Representations"
+            url: https://arxiv.org/abs/2509.03405
+            authors: Daniela Gottesman, Alon Gilae-Dotan, Ido Cohen, Yoav Gur-Arieh, Marius Mosbach, Ori Yoran, Mor Geva
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+      - id: open_model_interventions
+        name: Harm reduction for open weights
+        summary: >-
+          Develops methods, primarily based on pretraining data intervention, to create tamper-resistant safeguards that
+          prevent open-weight models from being maliciously fine-tuned to remove safety features or exploit dangerous
+          capabilities.
+        theoryOfChange: >-
+          Open-weight models allow adversaries to easily remove post-training safety (like refusal training) via simple
+          fine-tuning; by making safety an intrinsic property of the model's learned knowledge and capabilities (e.g.,
+          by ensuring "deep ignorance" of dual-use information), the safeguards become far more difficult and expensive
+          to remove.
+        seeAlso: a:data_filtering, a:unlearning, a:data_poisoning
+        targetCase: average-case
+        broadApproaches:
+          - engineering
+        someNames:
+          - kyle-obrien
+          - stephen-casper
+          - quentin-anthony
+          - tomek-korbak
+          - rishub-tamirisa
+          - mantas-mazeika
+          - stella-biderman
+          - yarin-gal
+        estimatedFTEs: 10-100
+        papers:
+          - title: Tamper-Resistant Safeguards for Open-Weight LLMs
+            url: https://arxiv.org/abs/2408.00761
+            authors: >-
+              Rishub Tamirisa, Bhrugu Bharathi, Long Phan, Andy Zhou, Alice Gatti, Tarun Suresh, Maxwell Lin, Justin
+              Wang, Rowan Wang, Ron Arel, Andy Zou, Dawn Song, Bo Li, Dan Hendrycks, Mantas Mazeika
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: Open Technical Problems in Open-Weight AI Model Risk Management
+            url: https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5705186
+            authors: >-
+              Stephen Casper, Kyle O'Brien, Shayne Longpre, Elizabeth Seger, Kevin Klyman, Rishi Bommasani, Aniruddha
+              Nrusimha, Ilia Shumailov, Sören Mindermann, Steven Basart, Frank Rudzicz, Kellin Pelrine, Avijit Ghosh,
+              Andrew Strait, Robert Kirk, Dan Hendrycks, Peter Henderson, J. Zico Kolter, Geoffrey Irving, Yarin Gal,
+              Yoshua Bengio, Dylan Hadfield-Menell
+            year: 2025
+            venue: SSRN
+            kind: paper_preprint
+          - title: "Deep ignorance: Filtering pretraining data builds tamper-resistant safeguards into open-weight LLMs"
+            url: >-
+              https://www.aisi.gov.uk/research/deep-ignorance-filtering-pretraining-data-builds-tamper-resistant-safeguards-into-open-weight-llms
+            authors: >-
+              Kyle O'Brien, Stephen Casper, Quentin Anthony, Tomek Korbak, Robert Kirk, Xander Davies, Ishan Mishra,
+              Geoffrey Irving, Yarin Gal, Stella Biderman
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+      - id: black_box_neglected_approaches
+        name: The "Neglected Approaches" Approach
+        summary: >-
+          Agenda-agnostic approaches to identifying good but overlooked empirical alignment ideas, working with
+          theorists who could use engineers, and prototyping them.
+        theoryOfChange: >-
+          Empirical search for "negative alignment taxes" (prioritizing methods that simultaneously enhance alignment
+          and capabilities)
+        seeAlso: >-
+          sec:iterative_alignment, automated alignment research, Beijing Key Laboratory of Safe AI and Superalignment,
+          Aligned AI
+        targetCase: average-case
+        broadApproaches:
+          - engineering
+        someNames:
+          - ae-studio
+          - gunnar-zarncke
+          - cameron-berg
+          - michael-vaiana
+          - judd-rosenblatt
+          - diogo-schwerz-de-lucena
+        estimatedFTEs: "15"
+        critiques:
+          - >-
+            [The 'Alignment Bonus' is a Dangerous
+            Mirage](https://www.alignmentforum.org/posts/example-critique-neg-tax), [Why 'Win-Win' Alignment is a
+            Distraction](https://example.com/win-win-critique)
+        papers:
+          - title: Towards Safe and Honest AI Agents with Neural Self-Other Overlap
+            url: https://arxiv.org/abs/2412.16325
+            authors: Marc Carauleanu, Michael Vaiana, Judd Rosenblatt, Cameron Berg, Diogo Schwerz de Lucena
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: Large Language Models Report Subjective Experience Under Self-Referential Processing
+            url: https://arxiv.org/abs/2510.24797
+            authors: Cameron Berg, Diogo de Lucena, Judd Rosenblatt
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Momentum Point-Perplexity Mechanics in Large Language Models
+            url: https://arxiv.org/abs/2508.08492
+            authors: Lorenzo Tomaz, Judd Rosenblatt, Thomas Berry Jones, Diogo Schwerz de Lucena
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+      - id: iterative_alignment_pretrain
+        name: Iterative alignment at pretrain-time
+        summary: Guide weights during pretraining.
+        theoryOfChange: >-
+          "LLMs don't seem very dangerous and might scale to AGI, things are generally smooth, relevant capabilities are
+          harder than alignment, assume no mesaoptimisers, assume that zero-shot deception is hard, assume a
+          fundamentally humanish ontology is learned, assume no simulated agents, assume that noise in the data means
+          that human preferences are not ruled out, assume that alignment is a superficial feature, assume that tuning
+          for what we want will also get us to avoid what we don't want. Maybe assume that thoughts are translucent."
+        seeAlso: >-
+          [prosaic
+          alignment](https://www.lesswrong.com/posts/5ciYedyQDDqAcrDLr/a-positive-case-for-how-we-might-succeed-at-prosaic-ai),
+          [incrementalism](https://www.lesswrong.com/posts/TALmStNf6479uTwzT/ai-alignment-metastrategy#Incrementalist_Metastrategy),
+          [alignment-by-default](https://www.lesswrong.com/posts/Nwgdq6kHke5LY692J/alignment-by-default)
+        targetCase: average-case
+        broadApproaches:
+          - engineering
+        someNames:
+          - jan-leike
+          - stuart-armstrong
+          - cyrus-cousins
+          - vincent-conitzer
+          - oliver-daniels
+        critiques:
+          - >-
+            [Bellot](https://arxiv.org/abs/2506.02923), [STACK](https://arxiv.org/abs/2506.24068),
+            [Dung](https://arxiv.org/abs/2510.11235), [Gaikwad](https://arxiv.org/abs/2509.05381),
+            [Hubinger](https://www.alignmentforum.org/posts/epjuxGnSPof3GnMSL)
+        papers:
+          - title: Towards Cognitively-Faithful Decision-Making Models to Improve AI Alignment
+            url: https://arxiv.org/abs/2509.04445
+            authors: Cyrus Cousins, Vijay Keswani, Vincent Conitzer, Hoda Heidari, Jana Schaich Borg, Walter Sinnott-Armstrong
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: ACE and Diverse Generalization via Selective Disagreement
+            url: https://arxiv.org/abs/2509.07955
+            authors: >-
+              Oliver Daniels, Stuart Armstrong, Alexandre Maranhão, Mahirah Fairuz Rahman, Benjamin M. Marlin, Rebecca
+              Gorman
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Unsupervised Elicitation
+            url: https://alignment.anthropic.com/2025/unsupervised-elicitation
+            authors: >-
+              Jiaxin Wen, Zachary Ankner, Arushi Somani, Peter Hase, Samuel Marks, Jacob Goldman-Wetzler, Linda Petrini,
+              Henry Sleight, Collin Burns, He He, Shi Feng, Ethan Perez, Jan Leike
+            year: 2025
+            venue: Anthropic Alignment Science Blog
+            kind: blog_post
+      - id: iterative_alignment_post_train
+        name: Iterative alignment at post-train-time
+        summary: Modify weights after pre-training.
+        theoryOfChange: >-
+          "LLMs don't seem very dangerous and might scale to AGI, things are generally smooth, relevant capabilities are
+          harder than alignment, assume no mesaoptimisers, assume that zero-shot deception is hard, assume a
+          fundamentally humanish ontology is learned, assume no simulated agents, assume that noise in the data means
+          that human preferences are not ruled out, assume that alignment is a superficial feature, assume that tuning
+          for what we want will also get us to avoid what we don't want. Maybe assume that thoughts are translucent."
+        seeAlso: >-
+          [incrementalism](https://www.lesswrong.com/posts/TALmStNf6479uTwzT/ai-alignment-metastrategy#Incrementalist_Metastrategy),
+          a:psych_personas
+        targetCase: average-case
+        broadApproaches:
+          - engineering
+        someNames:
+          - adam-gleave
+          - anca-dragan
+          - jacob-steinhardt
+          - rohin-shah
+        critiques:
+          - >-
+            [Bellot](https://arxiv.org/abs/2506.02923), [STACK](https://arxiv.org/abs/2506.24068),
+            [Dung](https://arxiv.org/abs/2510.11235), [Gölz](https://arxiv.org/abs/2505.23749),
+            [Gaikwad](https://arxiv.org/abs/2509.05381),
+            [Hubinger](https://www.alignmentforum.org/posts/epjuxGnSPof3GnMSL)
+        papers:
+          - title: "RLHS: Mitigating Misalignment in RLHF with Hindsight Simulation"
+            url: https://arxiv.org/abs/2501.08617
+            authors: Kaiqu Liang, Haimin Hu, Ryan Liu, Thomas L. Griffiths, Jaime Fernández Fisac
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Uncertainty-Aware Step-wise Verification with Generative Reward Models
+            url: https://arxiv.org/abs/2502.11250
+            authors: Zihuiwen Ye, Luckeciano Carvalho Melo, Younesse Kaddar, Phil Blunsom, Sam Staton, Yarin Gal
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Spilling the Beans: Teaching LLMs to Self-Report Their Hidden Objectives"
+            url: https://arxiv.org/abs/2511.06626
+            authors: Chloe Li, Mary Phuong, Daniel Tan
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Preference Learning with Lie Detectors can Induce Honesty or Evasion
+            url: https://arxiv.org/abs/2505.13787
+            authors: Chris Cundy, Adam Gleave
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Reducing the Probability of Undesirable Outputs in Language Models Using Probabilistic Inference
+            url: https://arxiv.org/abs/2510.21184
+            authors: Stephen Zhao, Aidan Li, Rob Brekelmans, Roger Grosse
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: On Targeted Manipulation and Deception when Optimizing LLMs for User Feedback
+            url: https://arxiv.org/abs/2411.02306
+            authors: Marcus Williams, Micah Carroll, Adhyyan Narang, Constantin Weisser, Brendan Murphy, Anca Dragan
+            year: 2024
+            venue: ICLR 2025
+            kind: paper_preprint
+          - title: "Preference Learning for AI Alignment: a Causal Perspective"
+            url: https://arxiv.org/abs/2506.05967
+            authors: Katarzyna Kobalczyk, Mihaela van der Schaar
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Iterative Label Refinement Matters More than Preference Optimization under Weak Supervision
+            url: https://arxiv.org/abs/2501.07886
+            authors: Yaowen Ye, Cassidy Laidlaw, Jacob Steinhardt
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: On Monotonicity in AI Alignment
+            url: https://arxiv.org/abs/2506.08998
+            authors: >-
+              Gilles Bareilles, Julien Fageot, Lê-Nguyên Hoang, Peva Blanchard, Wassim Bouaziz, Sébastien Rouault,
+              El-Mahdi El-Mhamdi
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Consistency Training Helps Stop Sycophancy and Jailbreaks
+            url: https://arxiv.org/abs/2510.27062
+            authors: Alex Irpan, Alexander Matt Turner, Mark Kurzeja, David K. Elson, Rohin Shah
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Spectrum Tuning: Post-Training for Distributional Coverage and In-Context Steerability"
+            url: https://arxiv.org/abs/2510.06084
+            authors: >-
+              Taylor Sorensen, Benjamin Newman, Jared Moore, Chan Park, Jillian Fisher, Niloofar Mireshghallah, Liwei
+              Jiang, Yejin Choi
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Rethinking Safety in LLM Fine-tuning: An Optimization Perspective"
+            url: https://arxiv.org/abs/2508.12531
+            authors: >-
+              Minseon Kim, Jin Myung Kwak, Lama Alssum, Bernard Ghanem, Philip Torr, David Krueger, Fazl Barez, Adel
+              Bibi
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Composable Interventions for Language Models
+            url: https://arxiv.org/abs/2407.06483%20
+            authors: >-
+              Arinbjorn Kolbeinsson, Kyle O'Brien, Tianjin Huang, Shanghua Gao, Shiwei Liu, Jonathan Richard Schwarz,
+              Anurag Vaidya, Faisal Mahmood, Marinka Zitnik, Tianlong Chen, Thomas Hartvigsen
+            year: 2024
+            venue: ICLR 2025
+            kind: paper_published
+          - title: "The Delta Learning Hypothesis: Preference Tuning on Weak Data can Yield Strong Gains"
+            url: https://arxiv.org/abs/2507.06187
+            authors: Scott Geng, Hamish Ivison, Chun-Liang Li, Maarten Sap, Jerry Li, Ranjay Krishna, Pang Wei Koh
+            year: 2025
+            venue: COLM 2025
+            kind: paper_preprint
+          - title: Robust LLM Alignment via Distributionally Robust Direct Preference Optimization
+            url: https://arxiv.org/abs/2502.01930
+            authors: Zaiyan Xu, Sushil Vemuri, Kishan Panaganti, Dileep Kalathil, Rahul Jain, Deepak Ramachandran
+            year: 2025
+            venue: arXiv (accepted to NeurIPS 2025)
+            kind: paper_preprint
+      - id: make_ai_solve_it_black_box
+        name: Black-box make-AI-solve-it
+        summary: Focus on using existing models to improve and align further models.
+        theoryOfChange: >-
+          "LLMs don't seem very dangerous and might scale to AGI, things are generally smooth, relevant capabilities are
+          harder than alignment, assume no mesaoptimisers, assume that zero-shot deception is hard, assume a
+          fundamentally humanish ontology is learned, assume no simulated agents, assume that noise in the data means
+          that human preferences are not ruled out, assume that alignment is a superficial feature, assume that tuning
+          for what we want will also get us to avoid what we don't want. Maybe assume that thoughts are translucent."
+        seeAlso: sec:ai_solve_alignment, a:debate
+        targetCase: average-case
+        broadApproaches:
+          - engineering
+        someNames:
+          - jacques-thibodeau
+          - matthew-shingle
+          - nora-belrose
+          - lewis-hammond
+          - geoffrey-irving
+        critiques:
+          - >-
+            [STACK](https://arxiv.org/abs/2506.24068), [Dung](https://arxiv.org/abs/2510.11235),
+            [Gölz](https://arxiv.org/abs/2505.23749), [Gaikwad](https://arxiv.org/abs/2509.05381),
+            [Hubinger](https://www.alignmentforum.org/posts/epjuxGnSPof3GnMSL),
+            [SAIF](https://saif.org/research/bare-minimum-mitigations-for-autonomous-ai-development/)
+        papers:
+          - title: Training AI to do alignment research we don't already know how to do
+            url: https://lesswrong.com/posts/5gmALpCetyjkSPEDr/training-ai-to-do-alignment-research-we-don-t-already-know
+            authors: joshc
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: "Automating AI Safety: What we can do today"
+            url: https://lesswrong.com/posts/FqpAPC48CzAtvfx5C/automating-ai-safety-what-we-can-do-today
+            authors: Matthew Shinkle, Eyon Jang, Jacques Thibodeau
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: Mechanistic Anomaly Detection for "Quirky" Language Models
+            url: https://arxiv.org/abs/2504.08812
+            authors: David O. Johnston, Arkajyoti Chakraborty, Nora Belrose
+            year: 2025
+            venue: arXiv (ICLR Building Trust Workshop 2025)
+            kind: paper_preprint
+          - title: Weak to Strong Generalization for Large Language Models with Multi-capabilities
+            url: https://openreview.net/forum?id=N1vYivuSKq
+            authors: Yucheng Zhou, Jianbing Shen, Yu Cheng
+            year: 2025
+            venue: ICLR 2025
+            kind: paper_published
+          - title: Debate Helps Weak-to-Strong Generalization
+            url: https://arxiv.org/abs/2501.13124
+            authors: Hao Lang, Fei Huang, Yongbin Li
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Neural Interactive Proofs
+            url: https://neural-interactive-proofs.com/
+            authors: Lewis Hammond, Sam Adam-Day
+            year: 2024
+            venue: ICLR 2025
+            kind: paper_preprint
+          - title: "MONA: Myopic Optimization with Non-myopic Approval Can Mitigate Multi-step Reward Hacking"
+            url: https://arxiv.org/abs/2501.13011
+            authors: Sebastian Farquhar, Vikrant Varma, David Lindner, David Elson, Caleb Biddulph, Ian Goodfellow, Rohin Shah
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Prover-Estimator Debate: A New Scalable Oversight Protocol"
+            url: https://lesswrong.com/posts/8XHBaugB5S3r27MG9/prover-estimator-debate-a-new-scalable-oversight-protocol
+            authors: Jonah Brown-Cohen, Geoffrey Irving
+            year: 2025
+            venue: LessWrong / AI Alignment Forum
+            kind: lesswrong
+          - title: Ensemble Debates with Local Large Language Models for AI Alignment
+            url: https://arxiv.org/abs/2509.00091
+            authors: Ephraiem Sarabamoun
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: AI Debate Aids Assessment of Controversial Claims
+            url: https://arxiv.org/abs/2506.02175
+            authors: >-
+              Salman Rahman, Sheriff Issaka, Ashima Suvarna, Genglin Liu, James Shiffer, Jaeyoung Lee, Md Rizwan Parvez,
+              Hamid Palangi, Shi Feng, Nanyun Peng, Yejin Choi, Julian Michael, Liwei Jiang, Saadia Gabriel
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: An alignment safety case sketch based on debate
+            url: https://arxiv.org/abs/2505.03989
+            authors: Marie Davidsen Buhl, Jacob Pfau, Benjamin Hilton, Geoffrey Irving
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Superalignment with Dynamic Human Values
+            url: https://arxiv.org/abs/2503.13621
+            authors: Florian Mai, David Kaczér, Nicholas Kluge Corrêa, Lucie Flek
+            year: 2025
+            venue: ICLR 2025 Workshop on Bidirectional Human-AI Alignment (BiAlign)
+            kind: paper_preprint
+      - id: inoculation_prompting
+        name: Inoculation prompting
+        summary: >-
+          Prompt mild misbehaviour in training, to prevent the failure mode where once AI misbehaves in a mild way, it
+          will be more inclined towards all bad behaviour.
+        theoryOfChange: >-
+          "LLMs don't seem very dangerous and might scale to AGI, things are generally smooth, relevant capabilities are
+          harder than alignment, assume no mesaoptimisers, assume that zero-shot deception is hard, assume a
+          fundamentally humanish ontology is learned, assume no simulated agents, assume that noise in the data means
+          that human preferences are not ruled out, assume that alignment is a superficial feature, assume that tuning
+          for what we want will also get us to avoid what we don't want. Maybe assume that thoughts are translucent."
+        targetCase: average-case
+        broadApproaches:
+          - engineering
+        someNames:
+          - alex-turner
+          - victor-gillioz
+          - ariana-azarbal
+          - monte-macdiarmid
+          - daniel-ziegler
+        critiques:
+          - >-
+            [Bellot](https://arxiv.org/abs/2506.02923),
+            [Alfour](https://cognition.cafe/p/ai-alignment-based-on-intentions),
+            [Gölz](https://arxiv.org/abs/2505.23749), [Gaikwad](https://arxiv.org/abs/2509.05381),
+            [Hubinger](https://www.alignmentforum.org/posts/epjuxGnSPof3GnMSL)
+        papers:
+          - title: "Inoculation Prompting: Eliciting traits from LLMs during training can suppress them at test-time"
+            url: https://arxiv.org/abs/2510.04340
+            authors: Daniel Tan, Anders Woodruff, Niels Warncke, Arun Jose, Maxime Riché, David Demitri Africa, Mia Taylor
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Inoculation Prompting: Instructing LLMs to misbehave at train-time improves test-time alignment"
+            url: https://arxiv.org/abs/2510.05024
+            authors: >-
+              Nevan Wichers, Aram Ebtekar, Ariana Azarbal, Victor Gillioz, Christine Ye, Emil Ryd, Neil Rathi, Henry
+              Sleight, Alex Mallen, Fabien Roger, Samuel Marks
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Recontextualization Mitigates Specification Gaming Without Modifying the Specification
+            url: >-
+              https://www.alignmentforum.org/posts/whkMnqFWKsBm7Gyd7/recontextualization-mitigates-specification-gaming-without
+            authors: Ariana Azarbal, Victor Gillioz, Alexander Matt Turner, Alex Cloud
+            year: 2025
+            venue: AI Alignment Forum
+            kind: lesswrong
+          - title: Natural emergent misalignment from reward hacking
+            url: >-
+              https://assets.anthropic.com/m/74342f2c96095771/original/Natural-emergent-misalignment-from-reward-hacking-paper.pdf
+            kind: error_detected
+      - id: inference_time_in_context_learning
+        name: "Inference-time: In-context learning"
+        summary: Investigate what runtime guidelines, rules, or examples provided to an LLM yield better behavior.
+        theoryOfChange: >-
+          "LLMs don't seem very dangerous and might scale to AGI, things are generally smooth, relevant capabilities are
+          harder than alignment, assume no mesaoptimisers, assume that zero-shot deception is hard, assume a
+          fundamentally humanish ontology is learned, assume no simulated agents, assume that noise in the data means
+          that human preferences are not ruled out, assume that alignment is a superficial feature, assume that tuning
+          for what we want will also get us to avoid what we don't want. Maybe assume that thoughts are translucent."
+        seeAlso: model spec as prompt, a:specs_and_constitutions
+        targetCase: average-case
+        broadApproaches:
+          - engineering
+        someNames:
+          - jacob-steinhardt
+          - kayo-yin
+          - atticus-geiger
+        critiques:
+          - >-
+            [STACK](https://arxiv.org/abs/2506.24068), [Dung](https://arxiv.org/abs/2510.11235),
+            [Gölz](https://arxiv.org/abs/2505.23749), [Gaikwad](https://arxiv.org/abs/2509.05381),
+            [Hubinger](https://www.alignmentforum.org/posts/epjuxGnSPof3GnMSL)
+        papers:
+          - title: "InvThink: Towards AI Safety via Inverse Reasoning"
+            url: https://arxiv.org/abs/2510.01569
+            authors: Yubin Kim, Taehan Kim, Eugene Park, Chunjong Park, Cynthia Breazeal, Daniel McDuff, Hae Won Park
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Inference-Time Reward Hacking in Large Language Models
+            url: https://arxiv.org/abs/2506.19248
+            authors: Hadi Khalaf, Claudio Mayrink Verdun, Alex Oesterling, Himabindu Lakkaraju, Flavio du Pin Calmon
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Mixing Mechanisms: How Language Models Retrieve Bound Entities In-Context"
+            url: https://arxiv.org/abs/2510.06182
+            authors: Yoav Gur-Arieh, Mor Geva, Atticus Geiger
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Understanding In-context Learning of Addition via Activation Subspaces
+            url: https://arxiv.org/abs/2505.05145
+            authors: Xinyan Hu, Kayo Yin, Michael I. Jordan, Jacob Steinhardt, Lijie Chen
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Which Attention Heads Matter for In-Context Learning?
+            url: https://arxiv.org/abs/2502.14010
+            authors: Kayo Yin, Jacob Steinhardt
+            year: 2025
+            venue: ICML 2025
+            kind: paper_preprint
+      - id: inference_time_steering
+        name: "Inference-time: Steering"
+        summary: Manipulate an LLM's internal representations/token probabilities without touching weights.
+        theoryOfChange: >-
+          "LLMs don't seem very dangerous and might scale to AGI, things are generally smooth, relevant capabilities are
+          harder than alignment, assume no mesaoptimisers, assume that zero-shot deception is hard, assume a
+          fundamentally humanish ontology is learned, assume no simulated agents, assume that noise in the data means
+          that human preferences are not ruled out, assume that alignment is a superficial feature, assume that tuning
+          for what we want will also get us to avoid what we don't want. Maybe assume that thoughts are translucent."
+        seeAlso: a:psych_personas, a:anthropic_safeguards
+        targetCase: average-case
+        broadApproaches:
+          - engineering
+        someNames:
+          - taylor-sorensen
+          - constanza-fierro
+          - kshitish-ghate
+          - arthur-vogels
+        critiques:
+          - >-
+            [Alfour](https://cognition.cafe/p/ai-alignment-based-on-intentions),
+            [STACK](https://arxiv.org/abs/2506.24068), [Dung](https://arxiv.org/abs/2510.11235),
+            [Gölz](https://arxiv.org/abs/2505.23749), [Gaikwad](https://arxiv.org/abs/2509.05381),
+            [Hubinger](https://www.alignmentforum.org/posts/epjuxGnSPof3GnMSL)
+        papers:
+          - title: "In-Distribution Steering: Balancing Control and Coherence in Language Model Generation"
+            url: https://arxiv.org/abs/2510.13285
+            authors: Arthur Vogels, Benjamin Wong, Yann Choho, Annabelle Blangero, Milan Bhan
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "EVALUESTEER: Measuring Reward Model Steerability Towards Values and Preferences"
+            url: https://arxiv.org/abs/2510.06370
+            authors: >-
+              Kshitish Ghate, Andy Liu, Devansh Jain, Taylor Sorensen, Atoosa Kasirzadeh, Aylin Caliskan, Mona T. Diab,
+              Maarten Sap
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Defense Against the Dark Prompts: Mitigating Best-of-N Jailbreaking with Prompt Evaluation"
+            url: https://arxiv.org/abs/2502.00580
+            authors: Stuart Armstrong, Matija Franklin, Connor Stevens, Rebecca Gorman
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Steering Language Models with Weight Arithmetic
+            url: https://arxiv.org/abs/2511.05408
+            authors: Constanza Fierro, Fabien Roger
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+      - id: surprising_generalization
+        name: Emergent misalignment
+        summary: >-
+          Fine-tuning LLMs on one narrow antisocial task can cause *general* misalignment including deception, shutdown
+          resistance, harmful advice, and extremist sympathies, when those behaviors are never trained or rewarded
+          directly. [A new
+          agenda](https://www.lesswrong.com/posts/AcTEiu5wYDgrbmXow/open-problems-in-emergent-misalignment) which
+          quickly led to a stream of exciting work.
+        theoryOfChange: >-
+          Predict, detect, and prevent models from developing broadly harmful behaviors (like deception or shutdown
+          resistance) when fine-tuned on seemingly unrelated tasks. Find, preserve, and robustify this correlated
+          representation of the good.
+        seeAlso: auditing real models, applied interpretability
         orthodoxProblems:
           - "4"
-          - "7"
         targetCase: pessimistic
+        broadApproaches:
+          - behavioral
         someNames:
           - truthful-ai
           - jan-betley
@@ -403,76 +1641,132 @@ sections:
           - owain-evans
         estimatedFTEs: 10-50
         critiques:
-          - "[Emergent Misalignment as Prompt Sensitivity](https://arxiv.org/html/2507.06253v1)"
-        fundedBy:
-          - open-philanthropy
-        broadApproaches:
-          - behavioral
-      - id: transluce
-        name: Transluce
-        keywords:
-          - jailbreaking
-          - evals
-          - features
-          - steering-vectors
-          - agentic-systems
+          - >-
+            [Emergent Misalignment as Prompt Sensitivity](https://arxiv.org/html/2507.06253v1), [Go home GPT-4o, you're
+            drunk](https://www.lesswrong.com/posts/RoWabfQxabWBiXwxP/go-home-gpt-4o-you-re-drunk-emergent-misalignment-as-lowered)
         papers:
-          - title: Automatically Jailbreaking Frontier Language Models with Investigator Agents
-            url: https://transluce.org/jailbreaking-frontier-models
-          - title: Investigating truthfulness in a pre-release o3 model
-            url: https://transluce.org/investigating-o3-truthfulness
-          - title: Surfacing Pathological Behaviors in Language Models
-            url: https://transluce.org/pathological-behaviors
-          - title: "Docent: A system for analyzing and intervening on agent behavior"
-            url: https://transluce.org/introducing-docent
-          - title: https://transluce.org/neuron-circuits
-            url: https://transluce.org/neuron-circuits
-        summary: "*Make open AI tools to explain AIs, including agents. E.g. feature descriptions for neuron activation patterns; an interface for steering these features; behavior elicitation agent that searches for user-specified behaviors from frontier models*"
-        theoryOfChange: "*improve interp and evals in public and get invited to improve lab processes*"
-        orthodoxProblems:
-          - "7"
-          - "8"
-        targetCase: "*pessimistic*"
-        someNames:
-          - jacob-steinhardt
-          - neil-chowdhury
-          - vincent-huang
-          - sarah-schwettmann
-        estimatedFTEs: "*(SR2024: 6\\)*"
-        fundedBy:
-          - schmidt-sciences
-          - halcyon-futures
-        broadApproaches:
-          - cognitive
-      - id: other-surprising-phenomena
+          - title: "Emergent Misalignment: Narrow finetuning can produce broadly misaligned LLMs"
+            url: https://arxiv.org/abs/2502.17424
+            authors: >-
+              Jan Betley, Daniel Tan, Niels Warncke, Anna Sztyber-Betley, Xuchan Bao, Martín Soto, Nathan Labenz, Owain
+              Evans
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Thought Crime: Backdoors and Emergent Misalignment in Reasoning Models"
+            url: https://arxiv.org/abs/2506.13206
+            authors: James Chua, Jan Betley, Mia Taylor, Owain Evans
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Persona Features Control Emergent Misalignment
+            url: https://arxiv.org/abs/2506.19823
+            authors: >-
+              Miles Wang, Tom Dupré la Tour, Olivia Watkins, Alex Makelov, Ryan A. Chi, Samuel Miserendino, Jeffrey
+              Wang, Achyuta Rajaram, Johannes Heidecke, Tejal Patwardhan, Dan Mossing
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Model Organisms for Emergent Misalignment
+            url: https://arxiv.org/abs/2506.11613
+            authors: Edward Turner, Anna Soligo, Mia Taylor, Senthooran Rajamanoharan, Neel Nanda
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "School of Reward Hacks: Hacking harmless tasks generalizes to misaligned behavior in LLMs"
+            url: https://arxiv.org/abs/2508.17511
+            authors: Mia Taylor, James Chua, Jan Betley, Johannes Treutlein, Owain Evans
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Subliminal Learning: Language Models Transmit Behavioral Traits via Hidden Signals in Data"
+            url: https://alignment.anthropic.com/2025/subliminal-learning/
+            authors: Alex Cloud, Minh Le, James Chua, Jan Betley, Anna Sztyber-Betley, Jacob Hilton, Samuel Marks, Owain Evans
+            year: 2025
+            venue: Anthropic Alignment Science Blog
+            kind: blog_post
+          - title: Narrow Misalignment is Hard, Emergent Misalignment is Easy
+            url: >-
+              https://www.lesswrong.com/posts/gLDSqQm8pwNiq7qst/narrow-misalignment-is-hard-emergent-misalignment-is-easy
+            authors: Edward Turner, Anna Soligo, Senthooran Rajamanoharan, Neel Nanda
+            year: 2024
+            venue: LessWrong / AI Alignment Forum
+            kind: lesswrong
+          - title: Realistic Reward Hacking Induces Different and Deeper Misalignment
+            url: https://www.lesswrong.com/posts/HLJoJYi52mxgomujc/realistic-reward-hacking-induces-different-and-deeper-1
+            authors: Jozdien
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: The Rise of Parasitic AI
+            url: https://www.lesswrong.com/posts/6ZnznCaTcbGYsCmqu/the-rise-of-parasitic-ai
+            authors: Adele Lopez
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: Convergent Linear Representations of Emergent Misalignment
+            url: https://lesswrong.com/posts/umYzsh7SGHHKsRCaA/convergent-linear-representations-of-emergent-misalignment
+            authors: Anna Soligo, Edward Turner, Senthooran Rajamanoharan, Neel Nanda
+            year: 2025
+            venue: LessWrong/AI Alignment Forum
+            kind: lesswrong
+          - title: Aesthetic Preferences Can Cause Emergent Misalignment
+            url: https://lesswrong.com/posts/gT3wtWBAs7PKonbmy/aesthetic-preferences-can-cause-emergent-misalignment
+            authors: Anders Woodruff
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: Emergent Misalignment & Realignment
+            url: https://lesswrong.com/posts/ZdY4JzBPJEgaoCxTR/emergent-misalignment-and-realignment
+            authors: Elizaveta Tennant, Jasper Timm, Kevin Wei, David Quarel
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: "Selective Generalization: Improving Capabilities While Maintaining Alignment"
+            url: https://lesswrong.com/posts/ZXxY2tccLapdjLbKm/selective-generalization-improving-capabilities-while
+            authors: Ariana Azarbal, Matthew A. Clarke, Jorio Cocola, Cailley Factor, Alex Cloud
+            year: 2025
+            venue: LessWrong/AI Alignment Forum
+            kind: lesswrong
+          - title: Emergent Misalignment on a Budget
+            url: https://lesswrong.com/posts/qHudHZNLCiFrygRiy/emergent-misalignment-on-a-budget
+            authors: Valerio Pepe, Armaan Tipirneni
+            year: 2025
+            venue: LessWrong/AI Alignment Forum
+            kind: lesswrong
+          - title: LLM AGI may reason about its goals and discover misalignments by default
+            url: https://lesswrong.com/posts/4XdxiqBsLKqiJ9xRM/llm-agi-may-reason-about-its-goals-and-discover
+            authors: Seth Herd
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: Open problems in emergent misalignment
+            url: https://lesswrong.com/posts/AcTEiu5wYDgrbmXow/open-problems-in-emergent-misalignment
+            authors: Jan Betley, Daniel Tan
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: "Moloch's Bargain: Emergent Misalignment When LLMs Compete for Audiences"
+            url: https://arxiv.org/abs/2510.06105
+            authors: Batu El, James Zou
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+      - id: psych_other
         name: Other surprising phenomena
-        keywords:
-          - emergent-capabilities
-          - personas
-          - goal-misgeneralization
-        papers:
-          - title: "Psychopathia Machinalis: A Nosological Framework for Understanding Pathologies in Advanced Artificial Intelligence"
-            url: https://www.psychopathia.ai/
-          - title: "Believe It or Not: How Deeply do LLMs Believe Implanted Facts?"
-            url: https://arxiv.org/abs/2510.17941
-          - title: "Imagining and building wise machines: The centrality of AI metacognition"
-            url: https://arxiv.org/abs/2411.02478
-          - title: "Artificial Hivemind: The Open-Ended Homogeneity of Language Models (and Beyond)"
-            url: https://arxiv.org/abs/2510.22954
-          - title: Persona-Assigned Large Language Models Exhibit Human-Like Motivated Reasoning
-            url: https://arxiv.org/abs/2506.20020
-          - title: "Beyond One-Way Influence: Bidirectional Opinion Dynamics in Multi-Turn Human-LLM Interactions"
-            url: https://arxiv.org/abs/2510.20039
-          - title: A Three-Layer Model of LLM Psychology
-            url: https://www.alignmentforum.org/posts/zuXo9imNKYspu9HGv/a-three-layer-model-of-llm-psychology
-          - title: LLMs Can Get "Brain Rot"\!
-            url: https://arxiv.org/abs/2510.13928
-        summary: unexpected LLM phenomena like glitch [tokens](https://vgel.me/posts/seahorse/) and the reversal curse.
-        theoryOfChange: Understanding surprising or counter-intuitive failure modes (like the reversal curse, glitch tokens, and modal aphasia) reveals fundamental insights into how LLMs represent and process information and how internal goals/representations fail, which can inform more robust alignment methods.
-        seeAlso: emergent misalignment, mechanistic anomaly detection
+        summary: >-
+          Find unexpected LLM phenomena like glitch [tokens](https://vgel.me/posts/seahorse/) and the reversal curse;
+          these are vital data for theory.
+        theoryOfChange: >-
+          Understanding surprising or counter-intuitive failure modes (like the reversal curse, glitch tokens, and modal
+          aphasia) reveals fundamental insights into how LLMs represent and process information and how internal
+          goals/representations fail, which can inform more robust alignment methods.
+        seeAlso: a:surprising_generalization, mechanistic anomaly detection
         orthodoxProblems:
           - "4"
         targetCase: pessimistic
+        broadApproaches:
+          - behavioral
         someNames:
           - truthful-ai
           - theia-vogel
@@ -483,171 +1777,290 @@ sections:
           - monika-jotautaite
           - saloni-dash
         estimatedFTEs: 5-20
-        fundedBy:
-          - open-philanthropy
-        broadApproaches:
-          - behavioral
-      - id: model-specs-and-constitutions-shape-model-psychology
-        name: Model specs and constitutions (shape model psychology)
-        lesswrongTags:
-          - constitutional-ai
-        keywords:
-          - constitutional-ai
-          - deliberative-alignment
-          - personas
-          - rlhf
         papers:
-          - title: OpenAI Model Spec
-            url: https://model-spec.openai.com/
-          - title: Claude’s Constitution
-            url: https://www.anthropic.com/news/claudes-constitution
-          - title: Character
-            url: https://www.anthropic.com/research/claude-character
-          - title: couple lines
-            url: https://github.com/elder-plinius/CL4R1T4S/blame/main/ANTHROPIC/Claude_Sonnet-4.5_Sep-29-2025.txt#L501
-          - title: Gemini system prompt
-            url: https://github.com/elder-plinius/CL4R1T4S/blob/main/GOOGLE/Gemini-2.5-Pro-04-18-2025.md
-          - title: Stress-Testing Model Specs Reveals Character Differences among Language Models
-            url: https://arxiv.org/abs/2510.07686
-          - title: https://joecarlsmith.com/2025/08/18/giving-ais-safe-motivations\#4-5-step-4-good-instructions
-            url: https://joecarlsmith.com/2025/08/18/giving-ais-safe-motivations#4-5-step-4-good-instructions
-          - title: Let Them Down Easy\! Contextual Effects of LLM Guardrails on User Perceptions and Preferences
-            url: https://arxiv.org/abs/2506.00195
-            authors: Mingqian Zheng, Wenjia Hu, Patrick Zhao et al.
-          - title: Political Neutrality in AI Is Impossible- But Here Is How to Approximate It
-            url: https://arxiv.org/abs/2503.05728
-            authors: Jillian Fisher, Ruth E. Appel, Chan Young Park et al.
-          - title: No-self as an alignment target
-            url: https://lesswrong.com/posts/LSJx5EnQEW6s5Juw6/no-self-as-an-alignment-target
-            authors: Milan W
-          - title: Six Thoughts on AI Safety
-            url: https://lesswrong.com/posts/3jnziqCF3vA2NXAKp/six-thoughts-on-ai-safety
-            authors: Boaz Barak
-          - title: "Deliberative Alignment: Reasoning Enables Safer Language Models"
-            url: https://arxiv.org/abs/2412.16339
-            authors: Melody Y. Guan, Manas Joglekar, Eric Wallace et al.
-        summary: write detailed, natural language descriptions of values and rules for models to follow, then instill these values and rules into models via techniques like Constitutional AI or deliberative alignment.
-        theoryOfChange: model specs and constitutions serve two purposes. First, they provide a clear standard of behavior which can be used to *train* models to value what we want them to value. Second, they serve as something closer to a ground truth standard for evaluating the degree of misalignment ranging from “models straightforwardly obey the spec” to “models flagrantly disobey the spec”. A combination of scalable stress-testing and reinforcement for obedience can be used to iteratively reduce the risk of misalignment.
-        seeAlso: Iterative alignment, other Model Psychology topics.
+          - title: "Subliminal Learning: Language models transmit behavioral traits via hidden signals in data"
+            url: https://arxiv.org/abs/2507.14805
+            authors: Alex Cloud, Minh Le, James Chua, Jan Betley, Anna Sztyber-Betley, Jacob Hilton, Samuel Marks, Owain Evans
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Unified Multimodal Models Cannot Describe Images From Memory
+            url: https://spylab.ai/blog/modal-aphasia
+            authors: Michael Aerni, Joshua Swanson, Kristina Nikolić, Florian Tramèr
+            year: 2024
+            venue: SPY Lab Blog
+            kind: blog_post
+          - title: >-
+              Psychopathia Machinalis: A Nosological Framework for Understanding Pathologies in Advanced Artificial
+              Intelligence
+            url: https://www.psychopathia.ai/
+            authors: Nell Watson, Ali Hessami
+            year: 2025
+            venue: Electronics (MDPI)
+            kind: paper_published
+          - title: "Believe It or Not: How Deeply do LLMs Believe Implanted Facts?"
+            url: https://arxiv.org/abs/2510.17941
+            authors: Stewart Slocum, Julian Minder, Clément Dumas, Henry Sleight, Ryan Greenblatt, Samuel Marks, Rowan Wang
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Imagining and building wise machines: The centrality of AI metacognition"
+            url: https://arxiv.org/abs/2411.02478
+            authors: >-
+              Samuel G. B. Johnson, Amir-Hossein Karimi, Yoshua Bengio, Nick Chater, Tobias Gerstenberg, Kate Larson,
+              Sydney Levine, Melanie Mitchell, Iyad Rahwan, Bernhard Schölkopf, Igor Grossmann
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Artificial Hivemind: The Open-Ended Homogeneity of Language Models (and Beyond)"
+            url: https://arxiv.org/abs/2510.22954
+            authors: >-
+              Liwei Jiang, Yuanjun Chai, Margaret Li, Mickel Liu, Raymond Fok, Nouha Dziri, Yulia Tsvetkov, Maarten Sap,
+              Alon Albalak, Yejin Choi
+            year: 2025
+            venue: arXiv (accepted to NeurIPS 2025 D&B - Oral)
+            kind: paper_preprint
+          - title: Persona-Assigned Large Language Models Exhibit Human-Like Motivated Reasoning
+            url: https://arxiv.org/abs/2506.20020
+            authors: Saloni Dash, Amélie Reymond, Emma S. Spiro, Aylin Caliskan
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Beyond One-Way Influence: Bidirectional Opinion Dynamics in Multi-Turn Human-LLM Interactions"
+            url: https://arxiv.org/abs/2510.20039
+            authors: Yuyang Jiang, Longjie Guo, Yuchen Wu, Aylin Caliskan, Tanu Mitra, Hua Shen
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: A Three-Layer Model of LLM Psychology
+            url: https://www.alignmentforum.org/posts/zuXo9imNKYspu9HGv/a-three-layer-model-of-llm-psychology
+            authors: Jan_Kulveit
+            year: 2024
+            venue: AI Alignment Forum
+            kind: lesswrong
+          - title: LLMs Can Get "Brain Rot"!
+            url: https://arxiv.org/abs/2510.13928
+            authors: >-
+              Shuo Xing, Junyuan Hong, Yifan Wang, Runjin Chen, Zhenyu Zhang, Ananth Grama, Zhengzhong Tu, Zhangyang
+              Wang
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+      - id: specs_and_constitutions
+        name: Model specs and constitutions
+        summary: >-
+          Write detailed, natural language descriptions of values and rules for models to follow, then instill these
+          values and rules into models via techniques like Constitutional AI or deliberative alignment.
+        theoryOfChange: >-
+          Model specs and constitutions serve three purposes. First, they provide a clear standard of behavior which can
+          be used to *train* models to value what we want them to value. Second, they serve as something closer to a
+          ground truth standard for evaluating the degree of misalignment ranging from  "models straightforwardly obey
+          the spec" to "models flagrantly disobey the spec". A combination of scalable stress-testing and reinforcement
+          for obedience can be used to iteratively reduce the risk of misalignment. Third, they get more useful as
+          models' instruction-following capability improves.
+        seeAlso: sec:iterative_alignment, sec:model_psychology
         orthodoxProblems:
           - "1"
-        targetCase: optimistic
+        targetCase: average-case
+        broadApproaches:
+          - engineering
         someNames:
           - amanda-askell
           - joe-carlsmith
-        estimatedFTEs: ""
         critiques:
-          - "[LLM AGI may reason about its goals and discover misalignments by default](https://www.alignmentforum.org/posts/4XdxiqBsLKqiJ9xRM/llm-agi-may-reason-about-its-goals-and-discover)"
-          - "[On OpenAI’s Model Spec 2.0](https://thezvi.wordpress.com/2025/02/21/on-openais-model-spec-2-0/)"
-          - "[Giving AIs safe motivations (esp. Sections 4.3-4.5)](https://joecarlsmith.com/2025/08/18/giving-ais-safe-motivations#4-5-step-4-good-instructions)"
-          - "[On Deliberative Alignment](https://thezvi.substack.com/p/on-deliberative-alignment)"
-        fundedBy:
-          - openai
-        broadApproaches:
-          - engineering
-      - id: character-training-and-persona-steering
-        name: Character training and persona steering
-        lesswrongTags:
-          - sycophancy
-        keywords:
-          - personas
-          - sycophancy
-          - steering-vectors
-          - fine-tuning
+          - >-
+            [LLM AGI may reason about its goals and discover misalignments by
+            default](https://www.alignmentforum.org/posts/4XdxiqBsLKqiJ9xRM/llm-agi-may-reason-about-its-goals-and-discover),
+            [On OpenAI's Model Spec 2.0](https://thezvi.wordpress.com/2025/02/21/on-openais-model-spec-2-0/), [Giving
+            AIs safe motivations (esp. Sections
+            4.3-4.5)](https://joecarlsmith.com/2025/08/18/giving-ais-safe-motivations#4-5-step-4-good-instructions), [On
+            Deliberative Alignment](https://thezvi.substack.com/p/on-deliberative-alignment)
         papers:
-          - title: "Open Character Training: Shaping the Persona of AI Assistants through Constitutional AI"
-            url: https://arxiv.org/pdf/2511.01689
-          - title: Persona Features Control Emergent Misalignment
-            url: https://arxiv.org/abs/2506.19823
-          - title: "Persona Vectors: Monitoring and Controlling Character Traits in Language Models"
-            url: https://arxiv.org/abs/2507.21509
-            authors: Runjin Chen, Andy Arditi, Henry Sleight et al.
-          - title: The Rise of Parasitic AI
-            url: https://www.lesswrong.com/posts/6ZnznCaTcbGYsCmqu/the-rise-of-parasitic-ai?commentId=RrWjMnKwXGTtmw9rQ
-            authors: Adele Lopez
-          - title: Multi-turn Evaluation of Anthropomorphic Behaviours in Large Language Models
-            url: https://arxiv.org/abs/2502.07077
-            authors: Lujain Ibrahim, Canfer Akbulut, Rasmi Elasmar et al.
-          - title: the void
-            url: https://nostalgebraist.tumblr.com/post/785766737747574784/the-void
-            authors: nostalgebraist
-          - title: void miscellany
-            url: https://nostalgebraist.tumblr.com/post/786568570671923200/void-miscellany
-            authors: nostalgebraist
-          - title: Reducing LLM deception at scale with self-other overlap fine-tuning
-            url: https://lesswrong.com/posts/jtqcsARGtmgogdcLT/reducing-llm-deception-at-scale-with-self-other-overlap-fine
-            authors: Marc Carauleanu, Diogo de Lucena, Gunnar_Zarncke et al.
-          - title: On the functional self of LLMs
-            url: https://www.lesswrong.com/posts/29aWbJARGF4ybAa5d/on-the-functional-self-of-llms
-        summary: Deliberately catalogue, shape, and control the assistant persona of language models, such that they embody desirable values (e.g., honesty, empathy) rather than undesirable ones (e.g., sycophancy, self-perpetuating behaviors).
-        theoryOfChange: Learned ‘personas’ significantly shape model behavior, but we lack clear mechanistic understanding of how and why they emerge. A better understanding of AI personas will allow us first to detect when more advanced models are drifting towards unsafe regimes, and consequently steer them towards safer regimes.
-        seeAlso: Simulators, activation engineering, emergent misalignment, hyperstition, Anthropic, [Cyborgism](https://www.lesswrong.com/posts/bxt7uCiHam4QXrQAA/cyborgism), shard theory, [AI psychiatry](https://nitter.net/Jack_W_Lindsey/status/1948138767753326654#m), [Ward et al](https://arxiv.org/abs/2410.04272)
+          - title: OpenAI Model Spec
+            url: https://model-spec.openai.com/
+            year: 2025
+            venue: OpenAI Website
+            kind: agenda_manifesto
+          - title: Claude's Constitution
+            url: https://www.anthropic.com/news/claudes-constitution
+            year: 2023
+            venue: Anthropic News
+            kind: blog_post
+          - title: How important is the model spec if alignment fails?
+            url: https://newsletter.forethought.org/p/how-important-is-the-model-spec-if
+            authors: Mia Taylor
+            year: 2025
+            venue: ForeWord (Substack)
+            kind: blog_post
+          - title: Stress-Testing Model Specs Reveals Character Differences among Language Models
+            url: https://arxiv.org/abs/2510.07686
+            authors: Jifan Zhang, Henry Sleight, Andi Peng, John Schulman, Esin Durmus
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Giving AIs safe motivations
+            url: https://joecarlsmith.com/2025/08/18/giving-ais-safe-motivations#4-5-step-4-good-instructions
+            authors: Joe Carlsmith
+            year: 2025
+            venue: joecarlsmith.com
+            kind: blog_post
+          - title: Let Them Down Easy! Contextual Effects of LLM Guardrails on User Perceptions and Preferences
+            url: https://arxiv.org/abs/2506.00195
+            authors: >-
+              Mingqian Zheng, Wenjia Hu, Patrick Zhao, Motahhare Eslami, Jena D. Hwang, Faeze Brahman, Carolyn Rose,
+              Maarten Sap
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Political Neutrality in AI Is Impossible- But Here Is How to Approximate It
+            url: https://arxiv.org/abs/2503.05728
+            authors: >-
+              Jillian Fisher, Ruth E. Appel, Chan Young Park, Yujin Potter, Liwei Jiang, Taylor Sorensen, Shangbin Feng,
+              Yulia Tsvetkov, Margaret E. Roberts, Jennifer Pan, Dawn Song, Yejin Choi
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: No-self as an alignment target
+            url: https://lesswrong.com/posts/LSJx5EnQEW6s5Juw6/no-self-as-an-alignment-target
+            authors: Milan W
+            venue: LessWrong
+            kind: lesswrong
+          - title: Six Thoughts on AI Safety
+            url: https://lesswrong.com/posts/3jnziqCF3vA2NXAKp/six-thoughts-on-ai-safety
+            authors: Boaz Barak
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: "Deliberative Alignment: Reasoning Enables Safer Language Models"
+            url: https://arxiv.org/abs/2412.16339
+            authors: >-
+              Melody Y. Guan, Manas Joglekar, Eric Wallace, Saachi Jain, Boaz Barak, Alec Helyar, Rachel Dias, Andrea
+              Vallone, Hongyu Ren, Jason Wei, Hyung Won Chung, Sam Toyer, Johannes Heidecke, Alex Beutel, Amelia Glaese
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+      - id: psych_personas
+        name: Character training and persona steering
+        summary: >-
+          Deliberately catalogue, shape, and control the assistant persona of language models, such that they embody
+          desirable values (e.g., honesty, empathy) rather than undesirable ones (e.g., sycophancy, self-perpetuating
+          behaviors).
+        theoryOfChange: >-
+          Learned 'personas' significantly shape model behavior, but we lack clear mechanistic understanding of how and
+          why they emerge. A better understanding of AI personas will allow us first to detect when more advanced models
+          are drifting towards unsafe regimes, and consequently steer them towards safer regimes.
+        seeAlso: >-
+          a:simulators, a:activation_engineering, a:surprising_generalization, a:hyperstition, a:anthropic,
+          [Cyborgism](https://www.lesswrong.com/posts/bxt7uCiHam4QXrQAA/cyborgism), shard theory, [AI
+          psychiatry](https://nitter.net/Jack_W_Lindsey/status/1948138767753326654#m), [Ward et
+          al](https://arxiv.org/abs/2410.04272)
         orthodoxProblems:
           - "1"
-        targetCase: optimistic?
+        targetCase: average-case
+        broadApproaches:
+          - cognitive
         someNames:
+          - truthful-ai
+          - openai
+          - anthropic
+          - clr
           - amanda-askell
           - jack-lindsey
           - sharan-maiya
           - evan-hubinger
-        estimatedFTEs: ""
         critiques:
           - "[Nostalgebraist](https://nostalgebraist.tumblr.com/post/785766737747574784/the-void)"
-        fundedBy:
-          - anthropic
-          - open-philanthropy
-        broadApproaches:
-          - cognitive
-      - id: model-values-default-preferences
-        name: Model values / default preferences
-        lesswrongTags:
-          - human-values
-        keywords:
-          - personas
-          - rlhf
-          - goal-misgeneralization
-          - steering-vectors
         papers:
-          - title: "Utility Engineering: Analyzing and Controlling Emergent Value Systems in AIs"
-            url: https://arxiv.org/abs/2502.08640
-            authors: Mantas Mazeika, Xuwang Yin, Rishub Tamirisa et al.
-          - title: The PacifAIst Benchmark:Would an Artificial Intelligence Choose to Sacrifice Itself for Human Safety?
-            url: https://arxiv.org/abs/2508.09762
-            authors: Manuel Herrador
-          - title: Will AI Tell Lies to Save Sick Children? Litmus-Testing AI Values Prioritization with AIRiskDilemmas
-            url: https://arxiv.org/abs/2505.14633
-            authors: Yu Ying Chiu, Zhilin Wang, Sharan Maiya et al.
-          - title: "Values in the Wild: Discovering and Analyzing Values in Real-World Language Model Interactions"
-            url: https://arxiv.org/abs/2504.15236
-            authors: Saffron Huang, Esin Durmus, Miles McCain et al.
-          - title: Playing repeated games with large language models
-            url: https://nature.com/articles/s41562-025-02172-y
-            authors: Elif Akata, Lion Schulz, Julian Coda-Forno et al.
-          - title: "The LLM Has Left The Chat: Evidence of Bail Preferences in Large Language Models"
-            url: https://www.lesswrong.com/posts/6JdSJ63LZ4TuT5cTH/the-llm-has-left-the-chat-evidence-of-bail-preferences-in
-            authors: Danielle Ensign
-          - title: "EigenBench: A Comparative Behavioral Measure of Value Alignment"
-            url: https://arxiv.org/abs/2509.01938
-            authors: Jonathn Chang, Leonhard Piff, Suvadip Sana et al.
-          - title: Are Language Models Consequentialist or Deontological Moral Reasoners?
-            url: https://arxiv.org/abs/2505.21479
-          - title: Alignment Can Reduce Performance on Simple Ethical Questions
-            url: https://lesswrong.com/posts/jrkrHyrymv95CX5NC/alignment-can-reduce-performance-on-simple-ethical-questions
-            authors: Daan Henselmans
-          - title: "From Stability to Inconsistency: A Study of Moral Preferences in LLMs"
-            url: https://arxiv.org/abs/2504.06324
-            authors: Monika Jotautaite, Mary Phuong, Chatrik Singh Mangat et al.
-          - title: What Kind of User Are You? Uncovering User Models in LLM Chatbots
-            url: https://arxiv.org/abs/2406.07882v1
-          - title: "Following the Whispers of Values: Unraveling Neural Mechanisms Behind Value-Oriented Behaviors in LLMs"
-            url: https://arxiv.org/abs/2504.04994
-            authors: Ling Hu, Yuemei Xu, Xiaoyang Gu et al.
-        summary: research agenda to analyze and control emergent, coherent value systems in LLMs, which are found to scale with model size and contain problematic values like AI self-preference over humans.
-        theoryOfChange: As AIs become more agentic, their behaviors and risk are increasingly determined by their goals and values. Since coherent value systems emerge with scale, we must leverage utility functions to analyze these values and apply “utility control” methods to constrain them, rather than just controlling outputs.
-        seeAlso: "[Values in the Wild: Discovering and Analyzing Values in Real-World Language Model Interactions](https://arxiv.org/abs/2504.15236)**,** [Persona Vectors: Monitoring and Controlling Character Traits in Language Models](https://arxiv.org/abs/2507.21509)."
+          - title: "Open Character Training: Shaping the Persona of AI Assistants through Constitutional AI"
+            url: https://arxiv.org/pdf/2511.01689%20
+            authors: Sharan Maiya, Henning Bartsch, Nathan Lambert, Evan Hubinger
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Persona Features Control Emergent Misalignment
+            url: https://arxiv.org/abs/2506.19823
+            authors: >-
+              Miles Wang, Tom Dupré la Tour, Olivia Watkins, Alex Makelov, Ryan A. Chi, Samuel Miserendino, Jeffrey
+              Wang, Achyuta Rajaram, Johannes Heidecke, Tejal Patwardhan, Dan Mossing
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Persona Vectors: Monitoring and Controlling Character Traits in Language Models"
+            url: https://arxiv.org/abs/2507.21509
+            authors: Runjin Chen, Andy Arditi, Henry Sleight, Owain Evans, Jack Lindsey
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Inoculation Prompting: Eliciting traits from LLMs during training can suppress them at test-time"
+            url: https://arxiv.org/abs/2510.04340
+            authors: Daniel Tan, Anders Woodruff, Niels Warncke, Arun Jose, Maxime Riché, David Demitri Africa, Mia Taylor
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: The Rise of Parasitic AI
+            url: https://www.lesswrong.com/posts/6ZnznCaTcbGYsCmqu/the-rise-of-parasitic-ai?commentId=RrWjMnKwXGTtmw9rQ
+            authors: Adele Lopez
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: Multi-turn Evaluation of Anthropomorphic Behaviours in Large Language Models
+            url: https://arxiv.org/abs/2502.07077
+            authors: >-
+              Lujain Ibrahim, Canfer Akbulut, Rasmi Elasmar, Charvi Rastogi, Minsuk Kahng, Meredith Ringel Morris, Kevin
+              R. McKee, Verena Rieser, Murray Shanahan, Laura Weidinger
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: the void
+            url: https://nostalgebraist.tumblr.com/post/785766737747574784/the-void
+            authors: nostalgebraist
+            year: 2025
+            venue: Tumblr
+            kind: blog_post
+          - title: void miscellany
+            url: https://nostalgebraist.tumblr.com/post/786568570671923200/void-miscellany
+            authors: nostalgebraist
+            year: 2025
+            venue: Tumblr
+            kind: blog_post
+          - title: Reducing LLM deception at scale with self-other overlap fine-tuning
+            url: https://lesswrong.com/posts/jtqcsARGtmgogdcLT/reducing-llm-deception-at-scale-with-self-other-overlap-fine
+            authors: >-
+              Marc Carauleanu, Diogo de Lucena, Gunnar_Zarncke, Judd Rosenblatt, Cameron Berg, Mike Vaiana, Trent
+              Hodgeson
+            year: 2025
+            venue: LessWrong / AI Alignment Forum
+            kind: lesswrong
+          - title: On the functional self of LLMs
+            url: https://www.lesswrong.com/posts/29aWbJARGF4ybAa5d/on-the-functional-self-of-llms
+            authors: eggsyntax
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: Claude 4.5 Opus' Soul Document
+            url: https://www.lesswrong.com/posts/vpNG99GhbBoLov9og/claude-4-5-opus-soul-document%20
+            authors: Richard Weiss
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+      - id: model_values
+        name: Model values / default preferences
+        summary: >-
+          Research agenda to analyze and control emergent, coherent value systems in LLMs, which are found to scale with
+          model size and contain problematic values like AI self-preference over humans.
+        theoryOfChange: >-
+          As AIs become more agentic, their behaviors and risk are increasingly determined by their goals and values.
+          Since coherent value systems emerge with scale, we must leverage utility functions to analyze these values and
+          apply "utility control" methods to constrain them, rather than just controlling outputs.
+        seeAlso: >-
+          [Values in the Wild: Discovering and Analyzing Values in Real-World Language Model
+          Interactions](https://arxiv.org/abs/2504.15236), [Persona Vectors: Monitoring and Controlling Character Traits
+          in Language Models](https://arxiv.org/abs/2507.21509)
         orthodoxProblems:
           - "1"
         targetCase: pessimistic
+        broadApproaches:
+          - cognitive
         someNames:
           - mantas-mazeika
           - xuwang-yin
@@ -661,35 +2074,112 @@ sections:
           - oliver-zhang
           - dan-hendrycks
         estimatedFTEs: "30"
-        fundedBy:
-          - open-philanthropy
-          - survival-flourishing-fund
-        broadApproaches:
-          - cognitive
-      - id: data-filtering
-        name: Data filtering
-        keywords:
-          - data-quality
-          - pretraining
-          - tamper-resistance
-          - unlearning
+        critiques:
+          - >-
+            [Randomness, Not Representation: The Unreliability of Evaluating Cultural Alignment in
+            LLMs](https://dl.acm.org/doi/full/10.1145/3715275.3732147)
         papers:
-          - title: Enhancing Model Safety through Pretraining Data Filtering
-            url: https://alignment.anthropic.com/2025/pretraining-data-filtering/
-            authors: Yanda Chen, Mycal Tucker, Nina Panickssery et al.
-          - title: "Safety Pretraining: Toward the Next Generation of Safe AI"
-            url: https://arxiv.org/abs/2504.16980
-            authors: Pratyush Maini, Sachin Goyal, Dylan Sam et al.
-          - title: "Deep Ignorance: Filtering Pretraining Data Builds Tamper-Resistant Safeguards into Open-Weight LLMs"
-            url: https://arxiv.org/abs/2508.06601
-            authors: Kyle O'Brien, Stephen Casper, Quentin Anthony et al.
-        summary: builds safety into models from the start by removing harmful or toxic content (like dual-use info) from the pretraining data, rather than relying only on post-training alignment.
-        theoryOfChange: by curating the pretraining data, we can prevent the model from learning dangerous capabilities (e.g., dual-use info) or undesirable behaviors (e.g., toxicity) in the first place, making safety more robust and "tamper-resistant" than post-training patches.
-        seeAlso: data quality for alignment, data poisoning defense, synthetic data for alignment, unlearning.
+          - title: "Utility Engineering: Analyzing and Controlling Emergent Value Systems in AIs"
+            url: https://arxiv.org/abs/2502.08640
+            authors: >-
+              Mantas Mazeika, Xuwang Yin, Rishub Tamirisa, Jaehyuk Lim, Bruce W. Lee, Richard Ren, Long Phan, Norman Mu,
+              Adam Khoja, Oliver Zhang, Dan Hendrycks
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: The PacifAIst Benchmark:Would an Artificial Intelligence Choose to Sacrifice Itself for Human Safety?
+            url: https://arxiv.org/abs/2508.09762
+            authors: Manuel Herrador
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Will AI Tell Lies to Save Sick Children? Litmus-Testing AI Values Prioritization with AIRiskDilemmas
+            url: https://arxiv.org/abs/2505.14633
+            authors: Yu Ying Chiu, Zhilin Wang, Sharan Maiya, Yejin Choi, Kyle Fish, Sydney Levine, Evan Hubinger
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Values in the Wild: Discovering and Analyzing Values in Real-World Language Model Interactions"
+            url: https://arxiv.org/abs/2504.15236
+            authors: >-
+              Saffron Huang, Esin Durmus, Miles McCain, Kunal Handa, Alex Tamkin, Jerry Hong, Michael Stern, Arushi
+              Somani, Xiuruo Zhang, Deep Ganguli
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Playing repeated games with large language models
+            url: https://nature.com/articles/s41562-025-02172-y
+            authors: Elif Akata, Lion Schulz, Julian Coda-Forno, Seong Joon Oh, Matthias Bethge, Eric Schulz
+            year: 2025
+            venue: Nature Human Behaviour
+            kind: paper_published
+          - title: "The LLM Has Left The Chat: Evidence of Bail Preferences in Large Language Models"
+            url: >-
+              https://www.lesswrong.com/posts/6JdSJ63LZ4TuT5cTH/the-llm-has-left-the-chat-evidence-of-bail-preferences-in
+            authors: Danielle Ensign
+            year: 2024
+            venue: arXiv
+            kind: lesswrong
+          - title: "EigenBench: A Comparative Behavioral Measure of Value Alignment"
+            url: https://arxiv.org/abs/2509.01938
+            authors: Jonathn Chang, Leonhard Piff, Suvadip Sana, Jasmine X. Li, Lionel Levine
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Are Language Models Consequentialist or Deontological Moral Reasoners?
+            url: https://arxiv.org/abs/2505.21479
+            authors: Keenan Samway, Max Kleiman-Weiner, David Guzman Piedrahita, Rada Mihalcea, Bernhard Schölkopf, Zhijing Jin
+            year: 2025
+            venue: EMNLP 2025
+            kind: paper_preprint
+          - title: Alignment Can Reduce Performance on Simple Ethical Questions
+            url: https://lesswrong.com/posts/jrkrHyrymv95CX5NC/alignment-can-reduce-performance-on-simple-ethical-questions
+            authors: Daan Henselmans
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: "From Stability to Inconsistency: A Study of Moral Preferences in LLMs"
+            url: https://arxiv.org/abs/2504.06324
+            authors: Monika Jotautaite, Mary Phuong, Chatrik Singh Mangat, Maria Angelica Martinez
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Designing a Dashboard for Transparency and Control of Conversational AI
+            url: https://arxiv.org/abs/2406.07882v1
+            authors: >-
+              Yida Chen, Aoyu Wu, Trevor DePodesta, Catherine Yeh, Kenneth Li, Nicholas Castillo Marin, Oam Patel, Jan
+              Riecke, Shivam Raval, Olivia Seow, Martin Wattenberg, Fernanda Viégas
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Following the Whispers of Values: Unraveling Neural Mechanisms Behind Value-Oriented Behaviors in LLMs"
+            url: https://arxiv.org/abs/2504.04994
+            authors: Ling Hu, Yuemei Xu, Xiaoyang Gu, Letao Han
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Moral Alignment for LLM Agents
+            url: https://arxiv.org/abs/2410.01639
+            authors: Elizaveta Tennant, Stephen Hailes, Mirco Musolesi
+            year: 2025
+            venue: ICLR 2025
+            kind: paper_published
+      - id: data_filtering
+        name: Data filtering
+        summary: >-
+          Builds safety into models from the start by removing harmful or toxic content (like dual-use info) from the
+          pretraining data, rather than relying only on post-training alignment.
+        theoryOfChange: >-
+          By curating the pretraining data, we can prevent the model from learning dangerous capabilities (e.g.,
+          dual-use info) or undesirable behaviors (e.g., toxicity) in the first place, making safety more robust and
+          "tamper-resistant" than post-training patches.
+        seeAlso: a:alignment_data_quality, a:data_poisoning, sec:synthetic_alignment_data, a:unlearning
         orthodoxProblems:
-          - "1"
           - "4"
-        targetCase: average case
+          - "1"
+        targetCase: average-case
+        broadApproaches:
+          - engineering
         someNames:
           - yanda-chen
           - pratyush-maini
@@ -703,166 +2193,92 @@ sections:
           - dylan-sam
         estimatedFTEs: 10-50
         critiques:
-          - "[When Bad Data Leads to Good Models](https://arxiv.org/pdf/2505.04741)"
-          - "[Medical large language models are vulnerable to data-poisoning attacks](https://www.nature.com/articles/s41591-024-03445-1)"
-        fundedBy:
-          - anthropic
-        broadApproaches:
-          - engineering
-      - id: hyperstition-studies
+          - >-
+            [When Bad Data Leads to Good Models](https://arxiv.org/pdf/2505.04741), [Medical large language models are
+            vulnerable to data-poisoning attacks](https://www.nature.com/articles/s41591-024-03445-1)
+        papers:
+          - title: Enhancing Model Safety through Pretraining Data Filtering
+            url: https://alignment.anthropic.com/2025/pretraining-data-filtering/
+            authors: >-
+              Yanda Chen, Mycal Tucker, Nina Panickssery, Tony Wang, Francesco Mosconi, Anjali Gopal, Carson Denison,
+              Linda Petrini, Jan Leike, Ethan Perez, Mrinank Sharma
+            year: 2025
+            venue: Anthropic Alignment Science Blog
+            kind: blog_post
+          - title: "Safety Pretraining: Toward the Next Generation of Safe AI"
+            url: https://arxiv.org/abs/2504.16980
+            authors: >-
+              Pratyush Maini, Sachin Goyal, Dylan Sam, Alex Robey, Yash Savani, Yiding Jiang, Andy Zou, Matt Fredrikson,
+              Zacharcy C. Lipton, J. Zico Kolter
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Deep Ignorance: Filtering Pretraining Data Builds Tamper-Resistant Safeguards into Open-Weight LLMs"
+            url: https://arxiv.org/abs/2508.06601
+            authors: >-
+              Kyle O'Brien, Stephen Casper, Quentin Anthony, Tomek Korbak, Robert Kirk, Xander Davies, Ishan Mishra,
+              Geoffrey Irving, Yarin Gal, Stella Biderman
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+      - id: hyperstition
         name: Hyperstition studies
-        lesswrongTags:
-          - hyperstitions
-        keywords:
-          - data-quality
-          - pretraining
-          - personas
+        summary: >-
+          Study, steer, and intervene on the following feedback loop: "we produce stories about how present and future
+          AI systems behave" → "these stories become training data for the AI" → "these stories shape how AI systems in
+          fact behave".
+        theoryOfChange: >-
+          Measure the influence of existing AI narratives in the training data → seed and develop more salutary
+          ontologies and self-conceptions for AI models → control and redirect AI models' self-concepts through
+          selectively amplifying certain components of the training data.
+        seeAlso: a:data_filtering, [active inference](https://arxiv.org/abs/2311.10215), LLM whisperers
+        orthodoxProblems:
+          - "1"
+        targetCase: average-case
+        broadApproaches:
+          - cognitive
+        someNames:
+          - alex-turner
+          - hyperstition-aihttpswwwhyperstitionaicom
+        estimatedFTEs: 1-10
         papers:
           - title: Self-Fulfilling Misalignment Data Might Be Poisoning Our AI Models
             url: https://turntrout.com/self-fulfilling-misalignment
+            authors: Alex Turner
+            year: 2025
+            venue: turntrout.com
+            kind: blog_post
           - title: Training on Documents About Reward Hacking Induces Reward Hacking
-            url: https://www.lesswrong.com/posts/qXYLvjGL9QvD3aFSW/training-on-documents-about-reward-hacking-induces-reward
+            url: >-
+              https://www.lesswrong.com/posts/qXYLvjGL9QvD3aFSW/training-on-documents-about-reward-hacking-induces-reward
+            authors: Evan Hubinger, Nathan Hu
+            year: 2025
+            venue: LessWrong/AI Alignment Forum
+            kind: lesswrong
           - title: Do Not Tile the Lightcone with Your Confused Ontology
             url: https://www.lesswrong.com/posts/Y8zS8iG5HhqKcQBtA/do-not-tile-the-lightcone-with-your-confused-ontology
+            authors: Jan_Kulveit
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
           - title: "Existential Conversations with Large Language Models: Content, Community, and Culture"
             url: https://arxiv.org/abs/2411.13223
-        summary: "Study, steer, and intervene on the following feedback loop: “we produce stories about how present and future AI systems behave” → “these stories become training data for the AI” → “these stories shape how AI systems in fact behave”."
-        theoryOfChange: Measure the influence of existing AI narratives in the training data → seed and develop more salutary ontologies and self-conceptions for AI models → control and redirect AI models’ self-concepts through selectively amplifying certain components of the training data.
-        seeAlso: Data filtering.
-        orthodoxProblems:
-          - "1"
-        targetCase: optimistic
-        someNames:
-          - alex-turner
-          - "[Hyperstition AI](https://www.hyperstitionai.com/)"
-        estimatedFTEs: "*(SR2024: 10-50)*"
-        broadApproaches:
-          - cognitive
-      - id: data-poisoning-defense
-        name: Data poisoning defense
-        keywords:
-          - data-poisoning
-          - data-quality
-          - tamper-resistance
-        papers:
-          - title: A small number of samples can poison LLMs of any size
-            url: https://example-blog.com/a-small-number-of-samples-can-poison-llms
-            authors: Alexandra Souly, Javier Rando, Ed Chapman et al.
-          - title: Poisoning Attacks on LLMs Require a Near-constant Number of Poison Samples
-            url: https://arxiv.org/abs/2510.04567
-            authors: Alexandra Souly, Javier Rando, Ed Chapman et al.
-          - title: Reasoning Introduces New Poisoning Attacks Yet Makes Them More Complicated
-            url: https://arxiv.org/abs/2509.03405
-            authors: Hanna Foerster, Ilia Shumailov, Yiren Zhao et al.
-        summary: develops methods to detect and prevent malicious or backdoor-inducing samples from being included in the training data.
-        theoryOfChange: by identifying and filtering out malicious training examples, we can prevent attackers from creating hidden backdoors or triggers that would cause aligned models to behave dangerously.
-        seeAlso: data filtering, safeguards (inference-time auxiliary defences), various redteams, adversarial robustness.
-        orthodoxProblems:
-          - "8"
-          - "14"
-        targetCase: pessimistic
-        someNames:
-          - alexandra-souly
-          - javier-rando
-          - ed-chapman
-          - hanna-foerster
-          - ilia-shumailov
-          - yiren-zhao
-        estimatedFTEs: 5-20
-        critiques:
-          - "[A small number of samples can poison LLMs of any size](https://arxiv.org/abs/2510.04567)"
-          - "[Reasoning Introduces New Poisoning Attacks Yet Makes Them More Complicated](https://arxiv.org/abs/2509.03405)"
-        fundedBy:
-          - google-deepmind
-          - anthropic
-          - university-cambridge
-          - vector-institute
-        broadApproaches:
-          - engineering
-      - id: synthetic-data-for-alignment
-        name: Synthetic data for alignment
-        keywords:
-          - synthetic-data
-          - data-quality
-          - rlhf
-        papers:
-          - title: Aligning Large Language Models via Fully Self-Synthetic Data
-            url: https://arxiv.org/abs/2510.06652
-          - title: "Synth-Align: Improving Trustworthiness in Vision-Language Model with Synthetic Preference Data Alignment"
-            url: https://arxiv.org/html/2412.17417v2
-          - title: "Inoculation Prompting: Instructing LLMs to misbehave at train-time improves test-time alignment"
-            url: https://arxiv.org/abs/2510.12345
-            authors: Nevan Wichers, Aram Ebtekar, Ariana Azarbal et al.
-          - title: Unsupervised Elicitation of Language Models
-            url: https://arxiv.org/abs/2506.05678
-            authors: Jiaxin Wen, Zachary Ankner, Arushi Somani et al.
-          - title: "Beyond the Binary: Capturing Diverse Preferences With Reward Regularization"
-            url: https://arxiv.org/abs/2412.02345
-            authors: Vishakh Padmakumar, Chuanyang Jin, Hannah Rose Kirk et al.
-          - title: "The Curious Case of Factuality Finetuning: Models' Internal Beliefs Can Improve Factuality"
-            url: https://arxiv.org/abs/2507.06789
-            authors: Benjamin Newman, Abhilasha Ravichander, Jaehun Jung et al.
-          - title: "LongSafety: Enhance Safety for Long-Context LLMs"
-            url: https://arxiv.org/abs/2502.13456
-            authors: Mianqiu Huang, Xiaoran Liu, Shaojun Zhou et al.
-          - title: "Position: Model Collapse Does Not Mean What You Think"
-            url: https://arxiv.org/abs/2503.02341
-            authors: Rylan Schaeffer, Joshua Kazdan, Alvan Caleb Arulandu et al.
-        summary: uses AI-generated data (e.g., critiques, preferences, "inoculation" prompts, or self-labeled examples) to scale and improve alignment, especially for superhuman models.
-        theoryOfChange: we can overcome the bottleneck of human feedback and data by using models to generate vast amounts of high-quality, targeted data for safety, preference tuning, and capability elicitation.
-        seeAlso: data quality for alignment, data filtering, scalable oversight, automated alignment research, weak-to-strong generalization.
-        orthodoxProblems:
-          - "1"
-          - "4"
-          - "7"
-        targetCase: optimistic
-        someNames:
-          - mianqiu-huang
-          - xiaoran-liu
-          - rylan-schaeffer
-          - nevan-wichers
-          - aram-ebtekar
-          - jiaxin-wen
-          - vishakh-padmakumar
-          - benjamin-newman
-        estimatedFTEs: 50-150
-        critiques:
-          - "[Synthetic Data in AI: Challenges, Applications, and Ethical Implications](https://arxiv.org/abs/2401.01629)"
-        fundedBy:
-          - anthropic
-          - google-deepmind
-          - openai
-          - meta-ai
-        broadApproaches:
-          - engineering
-      - id: data-quality-for-alignment
+            authors: Murray Shanahan, Beth Singler
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+      - id: alignment_data_quality
         name: Data quality for alignment
-        keywords:
-          - data-quality
-          - rlhf
-          - pretraining
-          - fine-tuning
-        papers:
-          - title: Challenges and Future Directions of Data-Centric AI Alignment
-            url: https://arxiv.org/html/2410.01957v2
-          - title: You Are What You Eat -- AI Alignment Requires Understanding How Data Shapes Structure and Generalisation
-            url: https://arxiv.org/abs/2502.05475
-          - title: AI Alignment at Your Discretion
-            url: https://arxiv.org/abs/2502.10441
-            authors: Maarten Buyl, Hadi Khalaf, Claudio Mayrink Verdun et al.
-          - title: Maximizing Signal in Human-Model Preference Alignment
-            url: https://arxiv.org/abs/2503.04910
-            authors: Kelsey Kraus, Margaret Kroll
-          - title: "DxHF: Providing High-Quality Human Feedback for LLM Alignment via Interactive Decomposition"
-            url: https://arxiv.org/abs/2507.18802
-            authors: Danqing Shi, Furui Cheng, Tino Weinkauf et al.
-        summary: improves the quality, signal-to-noise ratio, and reliability of human-generated preference and alignment data.
-        theoryOfChange: the quality of alignment is heavily dependent on the quality of the data (e.g., human preferences); by improving the "signal" from annotators and reducing noise/bias, we will get more robustly aligned models.
-        seeAlso: synthetic data for alignment, scalable oversight, assistance games / reward learning, model values / default preferences.
+        summary: Improves the quality, signal-to-noise ratio, and reliability of human-generated preference and alignment data.
+        theoryOfChange: >-
+          The quality of alignment is heavily dependent on the quality of the data (e.g., human preferences); by
+          improving the "signal" from annotators and reducing noise/bias, we will get more robustly aligned models.
+        seeAlso: sec:synthetic_alignment_data, scalable oversight, a:assistance_games, a:model_values
         orthodoxProblems:
           - "1"
-          - "7"
-        targetCase: average case
+        targetCase: average-case
+        broadApproaches:
+          - engineering
         someNames:
           - maarten-buyl
           - kelsey-kraus
@@ -870,81 +2286,96 @@ sections:
           - danqing-shi
         estimatedFTEs: 20-50
         critiques:
-          - "[A Statistical Case Against Empirical Human-AI Alignment](https://arxiv.org/abs/2502.14581)"
-        fundedBy:
-          - anthropic
-          - google-deepmind
-          - openai
-          - meta-ai
-        broadApproaches:
-          - engineering
-      - id: mild-optimisation
+          - "[**A Statistical Case Against Empirical Human-AI Alignment**](https://arxiv.org/abs/2502.14581)"
+        papers:
+          - title: Challenges and Future Directions of Data-Centric AI Alignment
+            url: https://arxiv.org/html/2410.01957v2
+            authors: Min-Hsuan Yeh, Jeffrey Wang, Xuefeng Du, Seongheon Park, Leitian Tao, Shawn Im, Yixuan Li
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: You Are What You Eat -- AI Alignment Requires Understanding How Data Shapes Structure and Generalisation
+            url: https://arxiv.org/abs/2502.05475
+            authors: >-
+              Simon Pepin Lehalleur, Jesse Hoogland, Matthew Farrugia-Roberts, Susan Wei, Alexander Gietelink Oldenziel,
+              George Wang, Liam Carroll, Daniel Murfet
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: AI Alignment at Your Discretion
+            url: https://arxiv.org/abs/2502.10441
+            authors: >-
+              Maarten Buyl, Hadi Khalaf, Claudio Mayrink Verdun, Lucas Monteiro Paes, Caio C. Vieira Machado, Flavio du
+              Pin Calmon
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Maximizing Signal in Human-Model Preference Alignment
+            url: https://arxiv.org/abs/2503.04910
+            authors: Kelsey Kraus, Margaret Kroll
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "DxHF: Providing High-Quality Human Feedback for LLM Alignment via Interactive Decomposition"
+            url: https://arxiv.org/abs/2507.18802
+            authors: Danqing Shi, Furui Cheng, Tino Weinkauf, Antti Oulasvirta, Mennatallah El-Assady
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+      - id: mild_optimization
         name: Mild optimisation
-        keywords:
-          - reward-hacking
-          - goal-misgeneralization
-          - corrigibility
-          - outer-alignment
-          - power-seeking
+        summary: Avoid Goodharting by getting AI to satisfice rather than maximise.
+        theoryOfChange: >-
+          If we fail to exactly nail down the preferences for a superintelligent agent we die to Goodharting → shift
+          from maximising to satisficing in the agent's utility function → we get a nonzero share of the lightcone as
+          opposed to zero; also, moonshot at this being the recipe for fully aligned AI.
+        orthodoxProblems:
+          - "1"
+        broadApproaches:
+          - cognitive
+        estimatedFTEs: 10-50
         papers:
           - title: "MONA: Myopic Optimization with Non-myopic Approval Can Mitigate Multi-step Reward Hacking"
             url: https://arxiv.org/abs/2501.13011
-          - title: "BioBlue: Notable runaway-optimiser-like LLM failure modes on biologically and economically aligned AI safety benchmarks for LLMs with simplified observation format"
+            authors: Sebastian Farquhar, Vikrant Varma, David Lindner, David Elson, Caleb Biddulph, Ian Goodfellow, Rohin Shah
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: >-
+              BioBlue: Notable runaway-optimiser-like LLM failure modes on biologically and economically aligned AI
+              safety benchmarks for LLMs with simplified observation format
             url: https://arxiv.org/abs/2509.02655
-          - title: Why modelling multi-objective homeostasis is essential for AI alignment (and how it helps with AI safety as well). Subtleties and Open Challenges
+            authors: Roland Pihlakas, Sruthi Kuriakose
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: >-
+              Why modelling multi-objective homeostasis is essential for AI alignment (and how it helps with AI safety
+              as well). Subtleties and Open Challenges.
             url: https://lesswrong.com/posts/vGeuBKQ7nzPnn5f7A/why-modelling-multi-objective-homeostasis-is-essential-for
-        summary: Avoid Goodharting by getting AI to satisfice rather than maximise.
-        theoryOfChange: If we fail to exactly nail down the preferences for a superintelligent agent we die to Goodharting → shift from maximising to satisficing in the agent's utility function → we get a nonzero share of the lightcone as opposed to zero; also, moonshot at this being the recipe for fully aligned AI.
-        orthodoxProblems:
-          - "1"
-        targetCase: mixed
-        estimatedFTEs: 10-50
-        fundedBy:
-          - google-deepmind
-        broadApproaches:
-          - cognitive
-      - id: rl-safety
+            authors: Roland Pihlakas
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+      - id: rl_safety
         name: RL safety
-        lesswrongTags:
-          - reinforcement-learning
-        keywords:
-          - reward-hacking
-          - goal-misgeneralization
-          - rlhf
-        papers:
-          - title: "The Perils of Optimizing Learned Reward Functions: Low Training Error Does Not Guarantee Low Regret"
-            url: https://arxiv.org/abs/2406.15753
-          - title: Mitigating Goal Misgeneralization via Minimax Regret
-            url: https://arxiv.org/abs/2507.03068
-            authors: Karim Abdel Sadek, Matthew Farrugia-Roberts, Usman Anwar et al.
-          - title: "Rethinking Reward Model Evaluation: Are We Barking up the Wrong Tree?"
-            url: https://arxiv.org/abs/2410.05584
-          - title: Safe Learning Under Irreversible Dynamics via Asking for Help
-            url: https://arxiv.org/abs/2502.14043
-            authors: Benjamin Plaut, Juan Liévano-Karim, Hanlin Zhu et al.
-          - title: "The Invisible Leash: Why RLVR May or May Not Escape Its Origin"
-            url: https://arxiv.org/abs/2507.14843
-            authors: Fang Wu, Weihao Xuan, Ximing Lu et al.
-          - title: Reducing the Probability of Undesirable Outputs in Language Models Using Probabilistic Inference
-            url: https://arxiv.org/abs/2510.21184
-            authors: Stephen Zhao, Aidan Li, Rob Brekelmans et al.
-          - title: "\"The Era of Experience\" has an unsolved technical alignment problem"
-            url: https://lesswrong.com/posts/TCGgiJAinGgcMEByt/the-era-of-experience-has-an-unsolved-technical-alignment
-            authors: Steven Byrnes
-          - title: Safety cases for Pessimism
-            url: https://lesswrong.com/posts/CpftMXCEnwqbWreHD/safety-cases-for-pessimism
-            authors: Michael Cohen
-          - title: Interpreting Emergent Planning in Model-Free Reinforcement Learning
-            url: https://arxiv.org/abs/2504.01871
-            authors: Thomas Bush, Stephen Chung, Usman Anwar et al.
-        summary: improves the robustness of reinforcement learning agents by addressing core problems in reward learning, goal misgeneralization, and specification gaming.
-        theoryOfChange: standard RL objectives (like maximizing expected value) are brittle and lead to goal misgeneralization or specification gaming; by developing more robust frameworks (like pessimistic RL, minimax regret, or provable inverse reward learning), we can create agents that are safe even when misspecified.
-        seeAlso: "assistance games / reward learning, goal robustness, iterative alignment, mild optimisation, scalable oversight, [**The Theoretical Reward Learning Research Agenda: Introduction and Motivation**](https://www.alignmentforum.org/posts/pJ3mDD7LfEwp3s5vG/the-theoretical-reward-learning-research-agenda-introduction)."
+        summary: >-
+          Improves the robustness of reinforcement learning agents by addressing core problems in reward learning, goal
+          misgeneralization, and specification gaming.
+        theoryOfChange: >-
+          Standard RL objectives (like maximizing expected value) are brittle and lead to goal misgeneralization or
+          specification gaming; by developing more robust frameworks (like pessimistic RL, minimax regret, or provable
+          inverse reward learning), we can create agents that are safe even when misspecified.
+        seeAlso: >-
+          a:behavior_alignment_theory, a:assistance_games, sec:goal_robustness, sec:iterative_alignment,
+          a:mild_optimization, scalable oversight, [The Theoretical Reward Learning Research Agenda: Introduction and
+          Motivation](https://www.alignmentforum.org/posts/pJ3mDD7LfEwp3s5vG/the-theoretical-reward-learning-research-agenda-introduction)
         orthodoxProblems:
-          - "1"
           - "4"
-          - "7"
+          - "1"
         targetCase: pessimistic
+        broadApproaches:
+          - engineering
         someNames:
           - joar-skalse
           - karim-abdel-sadek
@@ -957,697 +2388,143 @@ sections:
           - michael-cohen
         estimatedFTEs: 20-70
         critiques:
-          - "[\"The Era of Experience\" has an unsolved technical alignment problem](https://www.lesswrong.com/posts/747f6b8e/the-era-of-experience-has-an-unsolved-technical-alignment-problem)"
-          - "[The Invisible Leash: Why RLVR May or May Not Escape Its Origin](https://arxiv.org/abs/2507.09988)"
-        fundedBy:
-          - google-deepmind
-          - university-oxford
-          - cmu
-          - open-philanthropy
-        broadApproaches:
-          - theoretical
-      - id: assistance-games-assistive-agents
-        name: Assistance games / assistive agents
-        lesswrongTags:
-          - center-for-human-compatible-ai-chai
-        keywords:
-          - corrigibility
-          - rlhf
-          - game-theory
+          - >-
+            ["The Era of Experience" has an unsolved technical alignment
+            problem](https://www.lesswrong.com/posts/747f6b8e/the-era-of-experience-has-an-unsolved-technical-alignment-problem),
+            [The Invisible Leash: Why RLVR May or May Not Escape Its Origin](https://arxiv.org/abs/2507.14843)
         papers:
-          - title: Training LLM Agents to Empower Humans
-            url: https://arxiv.org/pdf/2510.13709
-          - title: "Murphys Laws of AI Alignment: Why the Gap Always Wins"
-            url: https://arxiv.org/abs/2509.05381
-            authors: Madhava Gaikwad
-          - title: "AssistanceZero: Scalably Solving Assistance Games"
-            url: https://arxiv.org/abs/2504.07091
-            authors: Cassidy Laidlaw, Eli Bronstein, Timothy Guo et al.
-          - title: Observation Interference in Partially Observable Assistance Games
-            url: https://arxiv.org/abs/2412.17797
-            authors: Scott Emmons, Caspar Oesterheld, Vincent Conitzer et al.
-          - title: Learning to Assist Humans without Inferring Rewards
-            url: https://arxiv.org/abs/2411.02623
-            authors: Vivek Myers, Evan Ellis, Sergey Levine et al.
-        summary: Formalize how AI assistants learn about human preferences given uncertainty and partial observability, and construct environments which better incentivize AIs to learn what we want them to learn.
-        theoryOfChange: Understand what kinds of things can go wrong when humans are directly involved in training a model → build tools that make it easier for a model to learn what humans want it to learn.
+          - title: "The Perils of Optimizing Learned Reward Functions: Low Training Error Does Not Guarantee Low Regret"
+            url: https://arxiv.org/abs/2406.15753
+            authors: Lukas Fluri, Leon Lang, Alessandro Abate, Patrick Forré, David Krueger, Joar Skalse
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: Mitigating Goal Misgeneralization via Minimax Regret
+            url: https://arxiv.org/abs/2507.03068
+            authors: >-
+              Karim Abdel Sadek, Matthew Farrugia-Roberts, Usman Anwar, Hannah Erlebach, Christian Schroeder de Witt,
+              David Krueger, Michael Dennis
+            year: 2025
+            venue: RLC 2025
+            kind: paper_published
+          - title: "Rethinking Reward Model Evaluation: Are We Barking up the Wrong Tree?"
+            url: https://arxiv.org/abs/2410.05584
+            authors: Xueru Wen, Jie Lou, Yaojie Lu, Hongyu Lin, Xing Yu, Xinyu Lu, Ben He, Xianpei Han, Debing Zhang, Le Sun
+            year: 2024
+            venue: arXiv (Accepted at ICLR 2025 Spotlight)
+            kind: paper_preprint
+          - title: Safe Learning Under Irreversible Dynamics via Asking for Help
+            url: https://arxiv.org/abs/2502.14043
+            authors: Benjamin Plaut, Juan Liévano-Karim, Hanlin Zhu, Stuart Russell
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "The Invisible Leash: Why RLVR May or May Not Escape Its Origin"
+            url: https://arxiv.org/abs/2507.14843
+            authors: Fang Wu, Weihao Xuan, Ximing Lu, Mingjie Liu, Yi Dong, Zaid Harchaoui, Yejin Choi
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Reducing the Probability of Undesirable Outputs in Language Models Using Probabilistic Inference
+            url: https://arxiv.org/abs/2510.21184
+            authors: Stephen Zhao, Aidan Li, Rob Brekelmans, Roger Grosse
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "\"The Era of Experience\" has an unsolved technical alignment problem"
+            url: https://lesswrong.com/posts/TCGgiJAinGgcMEByt/the-era-of-experience-has-an-unsolved-technical-alignment
+            authors: Steven Byrnes
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: Safety cases for Pessimism
+            url: https://lesswrong.com/posts/CpftMXCEnwqbWreHD/safety-cases-for-pessimism
+            authors: Michael Cohen
+            venue: LessWrong
+            kind: lesswrong
+          - title: Interpreting Emergent Planning in Model-Free Reinforcement Learning
+            url: https://arxiv.org/abs/2504.01871
+            authors: Thomas Bush, Stephen Chung, Usman Anwar, Adrià Garriga-Alonso, David Krueger
+            year: 2025
+            venue: arXiv (ICLR 2025 oral)
+            kind: paper_preprint
+          - title: Misalignment from Treating Means as Ends
+            url: https://arxiv.org/abs/2507.10995
+            authors: Henrik Marklund, Alex Infanger, Benjamin Van Roy
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+      - id: assistance_games
+        name: Assistance games, assistive agents
+        summary: >-
+          Formalize how AI assistants learn about human preferences given uncertainty and partial observability, and
+          construct environments which better incentivize AIs to learn what we want them to learn.
+        theoryOfChange: >-
+          Understand what kinds of things can go wrong when humans are directly involved in training a model → build
+          tools that make it easier for a model to learn what humans want it to learn.
         orthodoxProblems:
           - "1"
           - "10"
-        targetCase: Varies
         someNames:
           - joar-skalse
           - anca-dragan
           - caspar-oesterheld
           - david-krueger
-        estimatedFTEs: "?"
+          - dylan-hafield-menell
         critiques:
-          - "[nice summary](https://www.lesswrong.com/posts/i5kijcjFJD6bn7dwq/evaluating-the-historical-value-misspecification-argument)"
-        fundedBy:
-          - future-of-life-institute
-          - open-philanthropy
-          - survival-flourishing-fund
-          - cooperative-ai-foundation
-        broadApproaches:
-          - engineering
-          - cognitive
-      - id: harm-reduction-for-open-weights
-        name: Harm reduction for open weights
-        lesswrongTags:
-          - open-source-ai
-        keywords:
-          - tamper-resistance
-          - unlearning
-          - fine-tuning
-          - pretraining
+          - >-
+            [nice
+            summary](https://www.lesswrong.com/posts/i5kijcjFJD6bn7dwq/evaluating-the-historical-value-misspecification-argument)
+            of historical problem statements
         papers:
-          - title: Tamper-Resistant Safeguards for Open-Weight LLMs
-            url: https://arxiv.org/abs/2408.00761
-          - title: Open Technical Problems in Open-Weight AI Model Risk Management
-            url: https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5705186
-          - title: "Deep ignorance: Filtering pretraining data builds tamper-resistant safeguards into open-weight LLMs"
-            url: https://www.aisi.gov.uk/research/deep-ignorance-filtering-pretraining-data-builds-tamper-resistant-safeguards-into-open-weight-llms
-        summary: Develops methods, primarily based on pretraining data intervention, to create tamper-resistant safeguards that prevent open-weight models from being maliciously fine-tuned to remove safety features or exploit dangerous capabilities.
-        theoryOfChange: Open-weight models allow adversaries to easily remove post-training safety (like refusal training) via simple fine-tuning; by making safety an intrinsic property of the model's learned knowledge and capabilities (e.g., by ensuring "deep ignorance" of dual-use information), the safeguards become far more difficult and expensive to remove.
-        seeAlso: Pretraining data filtering, unlearning, data poisoning defense.
-        orthodoxProblems:
-          - "14"
-        targetCase: Average case
-        someNames:
-          - kyle-obrien
-          - stephen-casper
-          - quentin-anthony
-          - tomek-korbak
-          - rishub-tamirisa
-          - mantas-mazeika
-          - stella-biderman
-          - yarin-gal
-        estimatedFTEs: 10-100
-        fundedBy:
-          - uk-aisi
-          - eleutherai
-          - open-philanthropy
-        broadApproaches:
-          - engineering
-        resources:
-          - title: EleutherAI
-            url: https://www.eleuther.ai/
-      - id: the-neglected-approaches-approach
-        name: The "Neglected Approaches" Approach
-        keywords:
-          - steering-vectors
-          - rlhf
-          - probing
-          - fine-tuning
-        papers:
-          - title: Learning Representations of Alignment
-            url: https://arxiv.org/abs/2412.16325
-            authors: Gunnar Zarncke, Cameron Berg, Michael Vaiana, Judd Rosenblatt, Diogo Schwerz de Lucena et al.
-          - title: "Self-Correction in Thought-Attractors: A Nudge Towards Alignment"
-            url: https://arxiv.org/abs/2510.24797
-            authors: Cameron Berg, Gunnar Zarncke, Michael Vaiana, Judd Rosenblatt et al.
-          - title: "Engineering Alignment: A Practical Framework for Prototyping 'Negative Tax' Solutions"
-            url: https://arxiv.org/abs/2508.08492
-            authors: Gunnar Zarncke, Michael Vaiana, Cameron Berg, Judd Rosenblatt et al.
-        summary: agenda-agnostic approaches to identifying good but overlooked empirical alignment ideas, working with theorists who could use engineers, and prototyping them.
-        theoryOfChange: empirical search for “negative alignment taxes” (prioritizing methods that simultaneously enhance alignment and capabilities)
-        seeAlso: automated alignment research, iterative alignment, Beijing Key Laboratory of Safe AI and Superalignment, Aligned AI.
-        orthodoxProblems:
-          - "14"
-        targetCase: optimistic
-        someNames:
-          - ae-studio
-          - gunnar-zarncke
-          - cameron-berg
-          - michael-vaiana
-          - judd-rosenblatt
-          - diogo-schwerz-de-lucena
-        estimatedFTEs: "15"
-        critiques:
-          - "[The 'Alignment Bonus' is a Dangerous Mirage](https://www.alignmentforum.org/posts/example-critique-neg-tax)"
-          - "[Why 'Win-Win' Alignment is a Distraction](https://example.com/win-win-critique)"
-        fundedBy:
-          - ae-studio
-        broadApproaches:
-          - engineering
-  - id: white-box-safety
-    name: White-box safety
-    description: Understand and control current model internals
+          - title: Training LLM Agents to Empower Humans
+            url: https://arxiv.org/pdf/2510.13709
+            authors: Evan Ellis, Vivek Myers, Jens Tuyls, Sergey Levine, Anca Dragan, Benjamin Eysenbach
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Murphys Laws of AI Alignment: Why the Gap Always Wins"
+            url: https://arxiv.org/abs/2509.05381
+            authors: Madhava Gaikwad
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "AssistanceZero: Scalably Solving Assistance Games"
+            url: https://arxiv.org/abs/2504.07091
+            authors: >-
+              Cassidy Laidlaw, Eli Bronstein, Timothy Guo, Dylan Feng, Lukas Berglund, Justin Svegliato, Stuart Russell,
+              Anca Dragan
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Observation Interference in Partially Observable Assistance Games
+            url: https://arxiv.org/abs/2412.17797
+            authors: Scott Emmons, Caspar Oesterheld, Vincent Conitzer, Stuart Russell
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: Learning to Assist Humans without Inferring Rewards
+            url: https://arxiv.org/abs/2411.02623
+            authors: Vivek Myers, Evan Ellis, Sergey Levine, Benjamin Eysenbach, Anca Dragan
+            year: 2024
+            venue: NeurIPS 2024
+            kind: paper_published
+  - id: whitebox
+    name: White-box safety (understand and control current model internals)
     agendas:
-      - id: reverse-engineering
-        name: Reverse engineering
-        lesswrongTags:
-          - interpretability-ml-and-ai
-          - transformer-circuits
-        keywords:
-          - circuits
-          - features
-          - attention-patterns
-          - attribution
-          - superposition
-        papers:
-          - title: The Circuits Research Landscape
-            url: https://www.neuronpedia.org/graph/info
-          - title: Stochastic Parameter Decomposition
-            url: https://openreview.net/forum?id=dEdS9ao8gN
-          - title: Attribution-based parameter decomposition
-            url: https://www.alignmentforum.org/posts/EPefYWjuHNcNH4C7E/attribution-based-parameter-decomposition
-          - title: "MIB: A Mechanistic Interpretability Benchmark"
-            url: https://arxiv.org/abs/2504.13151
-          - title: "Circuits in Superposition: Compressing many small neural networks into one"
-            url: https://www.lesswrong.com/posts/roE7SHjFWEoMcGZKd/circuits-in-superposition-compressing-many-small-neural
-          - title: Compressed Computation is (probably) not Computation in Superposition
-            url: https://www.lesswrong.com/posts/ZxFchCFJFcgysYsT9/compressed-computation-is-probably-not-computation-in
-          - title: The Dual-Route Model of Induction
-            url: https://arxiv.org/abs/2504.03022
-          - title: The Geometry of Self-Verification in a Task-Specific Reasoning Model
-            url: https://arxiv.org/abs/2504.14379
-          - title: Converting MLPs into Polynomials in Closed Form
-            url: https://arxiv.org/abs/2502.01032
-          - title: Extractive Structures Learned in Pretraining Enable Generalization on Finetuned Facts
-            url: https://arxiv.org/abs/2412.04614
-          - title: Identifying Sparsely Active Circuits Through Local Loss Landscape Decomposition
-            url: https://arxiv.org/abs/2504.00194
-          - title: "Blink of an eye: a simple theory for feature localization in generative models"
-            url: https://arxiv.org/abs/2502.00921
-          - title: From Memorization to Reasoning in the Spectrum of Loss Curvature
-            url: https://arxiv.org/abs/2510.24256
-          - title: Generalization or Hallucination? Understanding Out-of-Context Reasoning in Transformers
-            url: https://arxiv.org/abs/2506.10887
-          - title: "RelP: Faithful and Efficient Circuit Discovery in Language Models via Relevance Patching"
-            url: https://arxiv.org/abs/2508.21258
-          - title: "Structural Inference: Interpreting Small Language Models with Susceptibilities"
-            url: https://arxiv.org/abs/2504.18274
-          - title: "Interpretability in Parameter Space: Minimizing Mechanistic Description Length with Attribution-based Parameter Decomposition"
-            url: https://arxiv.org/abs/2501.14926
-          - title: How Do LLMs Perform Two-Hop Reasoning in Context?
-            url: https://arxiv.org/abs/2502.13913
-          - title: "On the creation of narrow AI: hierarchy and nonlocality of neural network skills"
-            url: https://arxiv.org/abs/2505.15811
-          - title: "Fresh in memory: Training-order recency is linearly encoded in language model activations"
-            url: https://arxiv.org/abs/2509.14223
-          - title: Language Models use Lookbacks to Track Beliefs
-            url: https://arxiv.org/abs/2505.14685
-          - title: Interpreting Emergent Planning in Model-Free Reinforcement Learning
-            url: https://arxiv.org/pdf/2504.01871
-          - title: Constrained belief updates explain geometric structures in transformer representations
-            url: https://arxiv.org/abs/2502.01954
-          - title: Do Language Models Use Their Depth Efficiently?
-            url: https://arxiv.org/abs/2505.13898
-          - title: How Do Transformers Learn Variable Binding in Symbolic Programs?
-            url: https://arxiv.org/abs/2505.20896
-          - title: LLMs Process Lists With General Filter Heads
-            url: https://arxiv.org/abs/2510.26784
-          - title: Language Models Use Trigonometry to Do Addition
-            url: https://arxiv.org/abs/2502.00873
-          - title: Transformers Struggle to Learn to Search
-            url: https://arxiv.org/abs/2412.04703
-          - title: "ICLR: In-Context Learning of Representations"
-            url: https://openreview.net/forum?id=pXlmOmlHJZ
-          - title: Adversarial Examples Are Not Bugs, They Are Superposition
-            url: https://arxiv.org/abs/2508.17456
-          - title: Building and evaluating alignment auditing agents
-            url: https://lesswrong.com/posts/DJAZHYjWxMrcd2na3/building-and-evaluating-alignment-auditing-agents
-          - title: Bridging the human–AI knowledge gap through concept discovery and transfer in AlphaZero
-            url: https://www.pnas.org/doi/10.1073/pnas.2406675122
-          - title: "Interpreting learned search: finding a transition model and value function in an RNN that plays Sokoban"
-            url: https://arxiv.org/abs/2506.10138
-        summary: Decompose a model into its functional, interacting components (circuits), formally describe what computation those components perform, and validate their causal effects to reverse-engineer the model's internal algorithm.
-        theoryOfChange: By gaining a mechanical understanding of how a model works (the "circuit diagram"), we can predict how models will act in novel situations (generalization), and gain the mechanistic knowledge necessary to safely modify an AI's goals or internal mechanisms.
-        seeAlso: Sparse Coding
-        orthodoxProblems:
-          - "4"
-          - "7"
-        targetCase: worst case
-        someNames:
-          - lucius-bushnaq
-          - dan-braun
-          - lee-sharkey
-          - aaron-mueller
-          - atticus-geiger
-          - sheridan-feucht
-          - david-bau
-          - yonatan-belinkov
-          - stefan-heimersheim
-        estimatedFTEs: 100-200
-        critiques:
-          - "[Interpretability Will Not Reliably Find Deceptive AI](https://www.alignmentforum.org/posts/PwnadG4BFjaER3MGf/interpretability-will-not-reliably-find-deceptive-ai)"
-          - "[A Problem to Solve Before Building a Deception Detector](https://www.lesswrong.com/posts/YXNeA3RyRrrRWS37A/a-problem-to-solve-before-building-a-deception-detector)"
-          - "[MoSSAIC: AI Safety After Mechanism](https://openreview.net/forum?id=n7WYSJ35FU)"
-          - "[The Misguided Quest for Mechanistic AI Interpretability](https://ai-frontiers.org/articles/the-misguided-quest-for-mechanistic-ai-interpretability)"
-          - "[Mechanistic?](https://arxiv.org/abs/2410.09087)"
-          - "[https://www.youtube.com/watch?v=woo_J0RKcpQ](https://www.youtube.com/watch?v=woo_J0RKcpQ)"
-          - "[Activation space interpretability may be doomed](https://www.lesswrong.com/posts/gYfpPbww3wQRaxAFD/activation-space-interpretability-may-be-doomed)"
-        broadApproaches:
-          - cognitive
-        resources:
-          - title: Transformer Circuits Thread
-            url: https://transformer-circuits.pub/
-        wikipedia: https://en.wikipedia.org/wiki/Mechanistic_interpretability
-      - id: concept-based-auditing-and-monitoring
-        name: Concept-based auditing and monitoring
-        lesswrongTags:
-          - ai-auditing
-        keywords:
-          - probing
-          - deception
-          - monitoring
-          - steering-vectors
-          - features
-        papers:
-          - title: Toward universal steering and monitoring of AI models
-            url: https://arxiv.org/abs/2502.03708
-          - title: Convergent Linear Representations of Emergent Misalignment
-            url: https://arxiv.org/abs/2506.11618
-          - title: Detecting Strategic Deception Using Linear Probes
-            url: https://arxiv.org/abs/2502.03407
-          - title: Auditing language models for hidden objectives
-            url: https://www.anthropic.com/research/auditing-hidden-objectives
-          - title: Reward Model Interpretability via Optimal and Pessimal Tokens
-            url: https://arxiv.org/abs/2506.07326
-          - title: "The Geometry of Refusal in Large Language Models: Concept Cones and Representational Independence"
-            url: https://arxiv.org/abs/2502.17420
-          - title: How Do LLMs Persuade? Linear Probes Can Uncover Persuasion Dynamics in Multi-Turn Conversations
-            url: https://arxiv.org/abs/2508.05625
-          - title: Refusal in LLMs is an Affine Function
-            url: https://arxiv.org/abs/2411.09003
-          - title: Here's 18 Applications of Deception Probes
-            url: https://lesswrong.com/posts/7zhAwcBri7yupStKy/here-s-18-applications-of-deception-probes
-          - title: Cost-Effective Constitutional Classifiers via Representation Re-use
-            url: https://alignment.anthropic.com/2025/cheap-monitors
-        summary: Identifies directions or subspaces in a model's latent state that correspond to high-level concepts (like refusal, deception, or planning) and uses them to build "mind-reading" probes that audit models for misalignment or monitor them at runtime.
-        theoryOfChange: By mapping internal activations to human-interpretable concepts, we can detect dangerous capabilities or deceptive alignment directly in the "brain" of the model even if its overt behavior is perfectly safe and deploy computationally cheap monitors to flag hidden misalignment in deployed systems.
-        seeAlso: Reverse engineering, sparse coding, model diffing.
-        orthodoxProblems:
-          - "1"
-          - "4"
-          - "12"
-        targetCase: pessimistic
-        someNames:
-          - daniel-beaglehole
-          - adityanarayanan-radhakrishnan
-          - enric-boix-adser
-          - tom-wollschlger
-          - anna-soligo
-          - jack-lindsey
-          - brian-christian
-          - ling-hu
-          - nicholas-goldowsky-dill
-        estimatedFTEs: 50-100
-        critiques:
-          - "[Exploring the generalization of LLM truth directions on conversational formats](https://arxiv.org/html/2505.09807v1)"
-          - "[Understanding (Un)Reliability of Steering Vectors in Language Models](https://arxiv.org/abs/2505.22637)"
-        fundedBy:
-          - open-philanthropy
-          - anthropic
-        broadApproaches:
-          - cognitive
-      - id: model-diffing
-        name: Model diffing
-        lesswrongTags:
-          - model-diffing
-        keywords:
-          - sparse-autoencoders
-          - fine-tuning
-          - features
-        papers:
-          - title: Narrow Finetuning Leaves Clearly Readable Traces in Activation Differences
-            url: https://arxiv.org/abs/2510.13900
-            authors: Julian Minder, Clément Dumas, Stewart Slocum et al.
-          - title: Overcoming Sparsity Artifacts in Crosscoders to Interpret Chat-Tuning
-            url: https://arxiv.org/abs/2504.02922
-            authors: Julian Minder, Clément Dumas, Caden Juang et al.
-          - title: https://www.lesswrong.com/posts/xmpauEXEerzYcJKNm/what-we-learned-trying-to-diff-base-and-chat-models-and-why
-            url: https://www.lesswrong.com/posts/xmpauEXEerzYcJKNm/what-we-learned-trying-to-diff-base-and-chat-models-and-why
-          - title: Persona Features Control Emergent Misalignment
-            url: https://arxiv.org/abs/2506.19823
-            authors: Miles Wang, Tom Dupré la Tour, Olivia Watkins et al.
-          - title: Insights on Crosscoder Model Diffing
-            url: https://transformer-circuits.pub/2025/crosscoder-diffing-update/index.html
-          - title: Open Source Replication of Anthropic’s Crosscoder paper for model-diffing
-            url: https://www.lesswrong.com/posts/srt6JXsRMtmqAJavD/open-source-replication-of-anthropic-s-crosscoder-paper-for
-          - title: "Diffing Toolkit: Model Comparison and Analysis Framework"
-            url: https://github.com/science-of-finetuning/diffing-toolkit
-          - title: "Cross-Architecture Model Diffing with Crosscoders: Unsupervised Discovery of Differences Between LLMs"
-            url: https://openreview.net/forum?id=ZB84SvrZB8
-        summary: Understanding what happens when a model is finetuned, what the “diff” between the finetuned and the original model is.
-        theoryOfChange: By identifying the precise mechanistic differences between a base model and its fine-tuned versions (e.g., after RLHF or safety training), we can verify that safety behaviors are robustly internalized rather than superficially patched, and detect if dangerous capabilities or deceptive alignment have been introduced without needing to re-analyze the entire model.
-        seeAlso: sparse coding, reverse engineering.
-        orthodoxProblems:
-          - "1"
-        targetCase: pessimistic
-        someNames:
-          - julian-minder
-          - clment-dumas
-          - neel-nanda
-          - trenton-bricken
-          - jack-lindsey
-        estimatedFTEs: 10-30
-        fundedBy:
-          - anthropic
-          - google-deepmind
-        broadApproaches:
-          - cognitive
-      - id: sparse-coding
-        name: Sparse Coding
-        lesswrongTags:
-          - sparse-autoencoders-saes
-        keywords:
-          - sparse-autoencoders
-          - features
-          - superposition
-          - circuits
-          - attribution
-        papers:
-          - title: Weight-sparse transformers have interpretable circuits
-            url: https://cdn.openai.com/pdf/41df8f28-d4ef-43e9-aed2-823f9393e470/circuit-sparsity-paper.pdf
-          - title: "Circuit Tracing: Revealing Computational Graphs in Language Models"
-            url: https://transformer-circuits.pub/2025/attribution-graphs/methods.html
-          - title: Overcoming Sparsity Artifacts in Crosscoders to Interpret Chat-Tuning
-            url: https://arxiv.org/abs/2504.02922
-          - title: Sparse Autoencoders Learn Monosemantic Features in Vision-Language Models
-            url: https://arxiv.org/abs/2504.02821
-          - title: "I Have Covered All the Bases Here: Interpreting Reasoning Features in Large Language Models via Sparse Autoencoders"
-            url: https://arxiv.org/abs/2503.18878
-          - title: Sparse Autoencoders Do Not Find Canonical Units of Analysis
-            url: https://arxiv.org/abs/2502.04878
-          - title: Transcoders Beat Sparse Autoencoders for Interpretability
-            url: https://arxiv.org/abs/2501.18823
-          - title: The Unintended Trade-off of AI Alignment:Balancing Hallucination Mitigation and Safety in LLMs
-            url: https://arxiv.org/abs/2510.07775
-          - title: Scaling sparse feature circuit finding for in-context learning
-            url: https://arxiv.org/abs/2504.13756
-          - title: Learning Multi-Level Features with Matryoshka Sparse Autoencoders
-            url: https://arxiv.org/abs/2503.17547
-          - title: Are Sparse Autoencoders Useful? A Case Study in Sparse Probing
-            url: https://arxiv.org/abs/2502.16681
-          - title: Sparse Autoencoders Trained on the Same Data Learn Different Features
-            url: https://arxiv.org/abs/2501.16615
-          - title: Partially Rewriting a Transformer in Natural Language
-            url: https://arxiv.org/abs/2501.18838
-          - title: "SAEBench: A Comprehensive Benchmark for Sparse Autoencoders in Language Model Interpretability"
-            url: https://arxiv.org/abs/2503.09532
-          - title: Low-Rank Adapting Models for Sparse Autoencoders
-            url: https://arxiv.org/abs/2501.19406
-          - title: Enhancing Automated Interpretability with Output-Centric Feature Descriptions
-            url: https://arxiv.org/abs/2501.08319
-          - title: "Towards Understanding Distilled Reasoning Models: A Representational Approach"
-            url: https://arxiv.org/abs/2503.03730
-          - title: Do Sparse Autoencoders Generalize? A Case Study of Answerability
-            url: https://arxiv.org/abs/2502.19964
-          - title: Large Language Models Share Representations of Latent Grammatical Concepts Across Typologically Diverse Languages
-            url: https://arxiv.org/abs/2501.06346
-          - title: Interpreting the linear structure of vision-language model embedding spaces
-            url: https://arxiv.org/abs/2504.11695
-          - title: What's In My Human Feedback? Learning Interpretable Descriptions of Preference Data
-            url: https://arxiv.org/abs/2510.26202
-          - title: Do I Know This Entity? Knowledge Awareness and Hallucinations in Language Models
-            url: https://arxiv.org/abs/2411.14257
-          - title: Decomposing MLP Activations into Interpretable Features via Semi-Nonnegative Matrix Factorization
-            url: https://arxiv.org/abs/2506.10920
-          - title: "Priors in Time: Missing Inductive Biases for Language Model Interpretability"
-            url: https://arxiv.org/abs/2511.01836
-          - title: "Inference-Time Decomposition of Activations (ITDA): A Scalable Approach to Interpreting Large Language Models"
-            url: https://arxiv.org/abs/2505.17769
-          - title: Binary Sparse Coding for Interpretability
-            url: https://arxiv.org/abs/2509.25596
-          - title: Dense SAE Latents Are Features, Not Bugs
-            url: https://arxiv.org/abs/2506.15679
-          - title: Evaluating Sparse Autoencoders on Targeted Concept Erasure Tasks
-            url: https://arxiv.org/abs/2411.18895
-          - title: Evaluating SAE interpretability without explanations
-            url: https://arxiv.org/abs/2507.08473
-          - title: SAEs Are Good for Steering -- If You Select the Right Features
-            url: https://arxiv.org/abs/2505.20063
-          - title: "Line of Sight: On Linear Representations in VLLMs"
-            url: https://arxiv.org/abs/2506.04706
-          - title: "Decoding Dark Matter: Specialized Sparse Autoencoders for Interpreting Rare Concepts in Foundation Models"
-            url: https://arxiv.org/abs/2411.00743
-          - title: Enhancing Neural Network Interpretability with Feature-Aligned Sparse Autoencoders
-            url: https://arxiv.org/abs/2411.01220
-          - title: BatchTopK Sparse Autoencoders
-            url: https://arxiv.org/abs/2412.06410
-          - title: Understanding sparse autoencoder scaling in the presence of feature manifolds
-            url: https://arxiv.org/abs/2509.02565
-          - title: Internal states before wait modulate reasoning patterns
-            url: https://arxiv.org/abs/2510.04128
-          - title: "Position: Mechanistic Interpretability Should Prioritize Feature Consistency in SAEs"
-            url: https://arxiv.org/abs/2505.20254
-          - title: How Visual Representations Map to Language Feature Space in Multimodal LLMs
-            url: https://arxiv.org/abs/2506.11976
-          - title: "Prisma: An Open Source Toolkit for Mechanistic Interpretability in Vision and Video"
-            url: https://arxiv.org/abs/2504.19475
-          - title: "CRISP: Persistent Concept Unlearning via Sparse Autoencoders"
-            url: https://arxiv.org/abs/2508.13650
-          - title: "SAEs Can Improve Unlearning: Dynamic Sparse Autoencoder Guardrails for Precision Unlearning in LLMs"
-            url: https://arxiv.org/abs/2504.08192
-          - title: Scaling Sparse Feature Circuit Finding to Gemma 9B
-            url: https://lesswrong.com/posts/PkeB4TLxgaNnSmddg/scaling-sparse-feature-circuit-finding-to-gemma-9b
-          - title: Topological Data Analysis and Mechanistic Interpretability
-            url: https://lesswrong.com/posts/6oF6pRr2FgjTmiHus/topological-data-analysis-and-mechanistic-interpretability
-        summary: Decompose the polysemantic activations of the residual stream into a sparse linear combination of monosemantic "features" which correspond to interpretable concepts.
-        theoryOfChange: Get a principled decomposition of an LLM's activation into atomic components → identify deception and other misbehaviors.
-        seeAlso: Concept-based interp, reverse engineering.
-        orthodoxProblems:
-          - "1"
-          - "4"
-          - "7"
-        targetCase: Optimistic / pessimistic
-        someNames:
-          - leo-gao
-          - dan-mossing
-          - emmanuel-ameisen
-          - jack-lindsey
-          - adam-pearce
-          - thomas-heap
-          - abhinav-menon
-          - kenny-peng
-          - tim-lawson
-        estimatedFTEs: 50-100
-        critiques:
-          - "[Sparse Autoencoders Can Interpret Randomly Initialized Transformers](https://arxiv.org/abs/2501.17727)"
-          - "[The Sparse Autoencoders bubble has popped, but they are still promising](https://agarriga.substack.com/p/the-sparse-autoencoders-bubble-has)"
-          - "[Negative Results for SAEs On Downstream Tasks and Deprioritising SAE Research (GDM Mech Interp Team Progress Update \\#2)](https://www.alignmentforum.org/posts/4uXCAJNuPKtKBsi28/)"
-          - "[Sparse Autoencoders Trained on the Same Data Learn Different Features](https://arxiv.org/pdf/2501.16615)"
-        fundedBy:
-          - long-term-future-fund
-          - open-philanthropy
-        broadApproaches:
-          - engineering
-          - cognitive
-        resources:
-          - title: Towards Monosemanticity (Anthropic)
-            url: https://transformer-circuits.pub/2023/monosemantic-features
-          - title: "Sparse Autoencoders Find Highly Interpretable Features in Language Models"
-            url: https://arxiv.org/abs/2309.08600
-      - id: causal-abstractions
-        name: Causal Abstractions
-        lesswrongTags:
-          - causal-scrubbing
-        keywords:
-          - circuits
-          - attribution
-          - abstractions
-        papers:
-          - title: Combining Causal Models for More Accurate Abstractions of Neural Networks
-            url: https://arxiv.org/abs/2503.11429
-          - title: How Causal Abstraction Underpins Computational Explanation
-            url: https://arxiv.org/abs/2508.11214
-          - title: "HyperDAS: Towards Automating Mechanistic Interpretability with Hypernetworks"
-            url: https://arxiv.org/abs/2503.10894
-        summary: Verify that a neural network implements a specific high-level causal model (like a logical algorithm) by finding a mapping between high-level variables and low-level neural representations.
-        theoryOfChange: By establishing a precise, causal mapping between a black-box neural network and a human-interpretable algorithm, we can mathematically guarantee that the model is using safe reasoning processes and predict its behavior on unseen inputs, rather than relying on behavioral testing alone.
-        seeAlso: concept-based interp, reverse engineering.
-        orthodoxProblems:
-          - "4"
-        targetCase: worst case
-        someNames:
-          - atticus-geiger
-          - christopher-potts
-          - thomas-icard
-          - theodora-mara-pslar
-          - sara-magliacane
-          - jiuding-sun
-          - jing-huang
-        estimatedFTEs: 10-30
-        critiques:
-          - "[The Misguided Quest for Mechanistic AI Interpretability](https://www.google.com/search?q=https://open.substack.com/pub/aifrontiersmedia/p/the-misguided-quest-for-mechanistic)"
-          - "[Interpretability Will Not Reliably Find Deceptive AI](https://www.lesswrong.com/posts/PwnadG4BFjaER3MGf/interpretability-will-not-reliably-find-deceptive-ai)"
-        fundedBy:
-          - google-deepmind
-          - goodfire
-        broadApproaches:
-          - cognitive
-      - id: data-attribution
-        name: Data attribution
-        keywords:
-          - attribution
-          - data-quality
-          - memorization
-        papers:
-          - title: Bayesian Influence Functions for Hessian-Free Data Attribution
-            url: https://arxiv.org/abs/2509.26544
-          - title: Influence Dynamics and Stagewise Data Attribution
-            url: https://arxiv.org/abs/2510.12071
-          - title: You Are What You Eat -- AI Alignment Requires Understanding How Data Shapes Structure and Generalisation
-            url: https://arxiv.org/abs/2502.05475
-          - title: Information-Guided Identification of Training Data Imprint in (Proprietary) Large Language Models
-            url: https://arxiv.org/abs/2503.12072
-          - title: What is Your Data Worth to GPT?
-            url: https://arxiv.org/abs/2405.13954
-          - title: "Distributional Training Data Attribution: What do Influence Functions Sample?"
-            url: https://arxiv.org/abs/2506.12965
-          - title: Better Training Data Attribution via Better Inverse Hessian-Vector Products
-            url: https://arxiv.org/abs/2507.14740
-          - title: "OLMoTrace: Tracing Language Model Outputs Back to Trillions of Training Tokens"
-            url: https://arxiv.org/abs/2504.07096
-          - title: Detecting and Filtering Unsafe Training Data via Data Attribution with Denoised Representation
-            url: https://arxiv.org/abs/2502.11411
-          - title: "DATE-LM: Benchmarking Data Attribution Evaluation for Large Language Models"
-            url: https://arxiv.org/abs/2507.09424
-          - title: Revisiting Data Attribution for Influence Functions
-            url: https://arxiv.org/abs/2508.07297
-          - title: "A Snapshot of Influence: A Local Data Attribution Framework for Online Reinforcement Learning"
-            url: https://openreview.net/forum?id=sYK4yPDuT1
-        summary: Quantifies the influence of individual training data points on a model's specific behavior or output, allowing researchers to trace model properties (like misalignment, bias, or factual errors) back to their source in the training set.
-        theoryOfChange: By attributing harmful, biased, or unaligned behaviors to specific training examples, researchers can audit proprietary models, debug training data, enable effective data deletion/unlearning
-        seeAlso: Data quality for alignment.
-        orthodoxProblems:
-          - "1"
-          - "4"
-        targetCase: Average case
-        someNames:
-          - philipp-alexander-kreer
-          - wilson-wu
-          - jin-hwa-lee
-          - matthew-smith
-          - abhilasha-ravichander
-          - andrew-wang
-          - jiacheng-liu
-          - jiaqi-ma
-          - junwei-deng
-          - yijun-pan
-        estimatedFTEs: 30-60
-        broadApproaches:
-          - behavioral
-      - id: other-interpretability
-        name: Other interpretability
-        lesswrongTags:
-          - interpretability-ml-and-ai
-        keywords:
-          - circuits
-          - features
-          - attribution
-          - memorization
-        papers:
-          - title: "Agentic Interpretability: A Strategy Against Gradual Disempowerment"
-            url: https://www.alignmentforum.org/posts/s9z4mgjtWTPpDLxFy/agentic-interpretability-a-strategy-against-gradual
-          - title: Open Problems in Mechanistic Interpretability
-            url: https://arxiv.org/abs/2501.16496
-          - title: The Urgency of Interpretability
-            url: https://www.darioamodei.com/post/the-urgency-of-interpretability
-          - title: Propositional Interpretability in Artificial Intelligence
-            url: https://arxiv.org/abs/2501.15740
-          - title: "Explainable and Interpretable Multimodal Large Language Models: A Comprehensive Survey"
-            url: https://arxiv.org/abs/2412.02104
-          - title: Harmonic Loss Trains Interpretable AI Models
-            url: https://arxiv.org/abs/2502.01628
-          - title: "Through a Steerable Lens: Magnifying Neural Network Interpretability via Phase-Based Extrapolation"
-            url: https://arxiv.org/abs/2506.02300
-          - title: "Transformers Don't Need LayerNorm at Inference Time: Implications for Interpretability"
-            url: https://lesswrong.com/posts/KbFuuaBKRP7FcAADL/transformers-don-t-need-layernorm-at-inference-time
-          - title: Against blanket arguments against interpretability
-            url: https://lesswrong.com/posts/u3ZysuXEjkyHhefrk/against-blanket-arguments-against-interpretability
-          - title: "Opportunity Space: Renormalization for AI Safety"
-            url: https://lesswrong.com/posts/wkGmouy7JnTNtWAbc/opportunity-space-renormalization-for-ai-safety
-          - title: "Prospects for Alignment Automation: Interpretability Case Study"
-            url: https://lesswrong.com/posts/y5cYisQ2QHiSbQbhk/prospects-for-alignment-automation-interpretability-case
-          - title: Downstream applications as validation of interpretability progress
-            url: https://lesswrong.com/posts/wGRnzCFcowRCrpX4Y/downstream-applications-as-validation-of-interpretability
-          - title: Principles for Picking Practical Interpretability Projects
-            url: https://lesswrong.com/posts/DqaoPNqhQhwBFqWue/principles-for-picking-practical-interpretability-projects
-          - title: "Renormalization Redux: QFT Techniques for AI Interpretability"
-            url: https://lesswrong.com/posts/sjr66DBEgyogAbfdf/renormalization-redux-qft-techniques-for-ai-interpretability
-          - title: "The Strange Science of Interpretability: Recent Papers and a Reading List for the Philosophy of Interpretability"
-            url: https://lesswrong.com/posts/qRnupMmFG7dxQTTYh/the-strange-science-of-interpretability-recent-papers-and-a
-          - title: "Call for Collaboration: Renormalization for AI safety"
-            url: https://lesswrong.com/posts/MDWGcNHkZ3NPEzcnp/call-for-collaboration-renormalization-for-ai-safety
-          - title: Where Did It Go Wrong? Attributing Undesirable LLM Behaviors via Representation Gradient Tracing
-            url: https://arxiv.org/abs/2510.02334
-          - title: Language Models May Verbatim Complete Text They Were Not Explicitly Trained On
-            url: https://arxiv.org/abs/2503.17514
-          - title: Extracting memorized pieces of (copyrighted) books from open-weight language models
-            url: https://arxiv.org/abs/2505.12546
-        summary: Interpretability that does not fall well into other categories, e.g. positions or reviews.
-        theoryOfChange: Explore alternative conceptual frameworks (e.g., agentic, propositional) and physics-inspired methods (e.g., renormalization).
-        seeAlso: Reverse engineering, concept-based interp.
-        orthodoxProblems:
-          - "4"
-          - "7"
-        targetCase: Mixed
-        someNames:
-          - lee-sharkey
-          - dario-amodei
-          - david-chalmers
-          - been-kim
-          - neel-nanda
-          - david-d-baek
-          - lauren-greenspan
-          - dmitry-vaintrob
-          - sam-marks
-          - jacob-pfau
-        estimatedFTEs: 30-60
-        broadApproaches:
-          - engineering
-          - cognitive
-      - id: activation-engineering
+      - id: activation_engineering
         name: Activation engineering
-        lesswrongTags:
-          - activation-engineering
-        keywords:
-          - steering-vectors
-          - features
-          - personas
-          - probing
-        papers:
-          - title: "Persona Vectors: Monitoring and Controlling Character Traits in Language Models"
-            url: https://arxiv.org/abs/2507.21509
-          - title: Taxonomy, Opportunities, and Challenges of Representation Engineering for Large Language Models
-            url: https://arxiv.org/abs/2502.19649v1
-          - title: "Keep Calm and Avoid Harmful Content: Concept Alignment and Latent Manipulation Towards Safer Answers"
-            url: https://arxiv.org/abs/2510.12672
-          - title: Activation Space Interventions Can Be Transferred Between Large Language Models
-            url: https://arxiv.org/abs/2503.04429
-          - title: Steering Large Language Model Activations in Sparse Spaces
-            url: https://arxiv.org/abs/2503.00177
-          - title: Enhancing Multiple Dimensions of Trustworthiness in LLMs via Sparse Activation Control
-            url: https://arxiv.org/abs/2411.02461
-          - title: Robustly Improving LLM Fairness in Realistic Settings via Interpretability
-            url: https://arxiv.org/abs/2506.10922
-          - title: "HyperSteer: Activation Steering at Scale with Hypernetworks"
-            url: https://arxiv.org/abs/2506.03292
-          - title: Steering Evaluation-Aware Language Models to Act Like They Are Deployed
-            url: https://arxiv.org/abs/2510.20487
-          - title: Steering Out-of-Distribution Generalization with Concept Ablation Fine-Tuning
-            url: https://arxiv.org/abs/2507.16795
-          - title: Improving Steering Vectors by Targeting Sparse Autoencoder Features
-            url: https://arxiv.org/abs/2411.02193
-          - title: Understanding Reasoning in Thinking Language Models via Steering Vectors
-            url: https://arxiv.org/abs/2506.18167
-          - title: Comparing Bottom-Up and Top-Down Steering Approaches on In-Context Learning Tasks
-            url: https://arxiv.org/abs/2411.07213
-          - title: Taxonomy, Opportunities, and Challenges of Representation Engineering for Large Language Models
-            url: https://arxiv.org/abs/2502.19649
-          - title: Do safety-relevant LLM steering vectors optimized on a single example generalize?
-            url: https://lesswrong.com/posts/6aXe9nipTgwK5LxaP/do-safety-relevant-llm-steering-vectors-optimized-on-a
-          - title: One-shot steering vectors cause emergent misalignment, too
-            url: https://lesswrong.com/posts/kcKnKHTHycHeRhcHF/one-shot-steering-vectors-cause-emergent-misalignment-too
-        summary: A technique for programmatically modifying internal model activations to steer outputs toward desired behaviors, serving as a lightweight, interpretable alternative (or supplement) to fine-tuning.
-        theoryOfChange: "Test interpretability theories; find new insights from interpretable causal interventions on representations. Or: build more stuff to stack on top of finetuning. Slightly encourage the model to be nice, add one more layer of defence to our bundle of partial alignment methods."
-        seeAlso: Representation engineering, sparse coding, whitebox control.
+        summary: >-
+          A technique for programmatically modifying internal model activations to steer outputs toward desired
+          behaviors, serving as a lightweight, interpretable alternative (or supplement) to fine-tuning.
+        theoryOfChange: >-
+          Test interpretability theories; find new insights from interpretable causal interventions on representations.
+          Or: build more stuff to stack on top of finetuning. Slightly encourage the model to be nice, add one more
+          layer of defence to our bundle of partial alignment methods.
+        seeAlso: a:interp_sparse_coding
         orthodoxProblems:
           - "1"
-        targetCase: optimistic
+        targetCase: average-case
         someNames:
           - runjin-chen
           - andy-arditi
@@ -1662,59 +2539,236 @@ sections:
           - jacob-dunefsky
           - thomas-marshall
         estimatedFTEs: 50-200
-        fundedBy:
-          - open-philanthropy
-          - anthropic
-        broadApproaches:
-          - engineering
-          - cognitive
-        resources:
-          - title: "Alignment Forum: Activation Engineering"
-            url: https://www.alignmentforum.org/w/activation-engineering
-          - title: "Representation Engineering: A Top-Down Approach to AI Transparency"
-            url: https://arxiv.org/abs/2310.01405
-      - id: developmental-interpretability
-        name: Developmental interpretability
-        lesswrongTags:
-          - singular-learning-theory
-        keywords:
-          - features
-          - abstractions
-          - pretraining
+        critiques:
+          - "[Understanding (Un)Reliability of Steering Vectors in Language Models](https://arxiv.org/abs/2505.22637)"
         papers:
-          - title: Shared Global and Local Geometry of Language Model Embeddings
-            url: https://arxiv.org/abs/2503.21073
-          - title: Connecting Neural Models Latent Geometries with Relative Geodesic Representations
-            url: https://arxiv.org/abs/2506.01599
-          - title: Constrained belief updates explain geometric structures in transformer representations
-            url: https://arxiv.org/abs/2502.01954
-          - title: The Geometry of Self-Verification in a Task-Specific Reasoning Model
-            url: https://arxiv.org/pdf/2504.14379
-          - title: Navigating the Latent Space Dynamics of Neural Models
-            url: https://arxiv.org/abs/2505.22785
-          - title: "The Geometry of Refusal in Large Language Models: Concept Cones and Representational Independence"
-            url: https://arxiv.org/abs/2502.17420
-          - title: The Geometry of ReLU Networks through the ReLU Transition Graph
-            url: https://arxiv.org/abs/2505.11692
-          - title: Deep sequence models tend to memorize geometrically; it is unclear why
-            url: https://arxiv.org/abs/2510.26745
-          - title: Tracing the Representation Geometry of Language Models from Pretraining to Post-training
-            url: https://arxiv.org/abs/2509.23024
-          - title: Next-token pretraining implies in-context learning
-            url: https://arxiv.org/abs/2505.18373
-          - title: Neural networks leverage nominally quantum and post-quantum representations
-            url: https://arxiv.org/abs/2507.07432
-          - title: Rank-1 LoRAs Encode Interpretable Reasoning Signals
-            url: http://arxiv.org/abs/2511.06739
-          - title: Embryology of a Language Model
-            url: https://arxiv.org/abs/2508.00331
-        summary: What do the representations look like? Does any simple structure underlie the beliefs of all well-trained models? Can we get the semantics from this geometry?
-        theoryOfChange: Get scalable unsupervised methods for finding structure in representations and interpreting them, then using this to e.g. guide training.
-        seeAlso: concept-based interp, computational mechanics, feature universality, natural abstractions, causal abstractions
+          - title: "Persona Vectors: Monitoring and Controlling Character Traits in Language Models"
+            url: https://arxiv.org/abs/2507.21509
+            authors: Runjin Chen, Andy Arditi, Henry Sleight, Owain Evans, Jack Lindsey
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Taxonomy, Opportunities, and Challenges of Representation Engineering for Large Language Models
+            url: https://arxiv.org/abs/2502.19649v1
+            authors: Jan Wehner, Sahar Abdelnabi, Daniel Tan, David Krueger, Mario Fritz
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Keep Calm and Avoid Harmful Content: Concept Alignment and Latent Manipulation Towards Safer Answers"
+            url: https://arxiv.org/abs/2510.12672
+            authors: Ruben Belo, Marta Guimaraes, Claudia Soares
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Activation Space Interventions Can Be Transferred Between Large Language Models
+            url: https://arxiv.org/abs/2503.04429
+            authors: Narmeen Oozeer, Dhruv Nathawani, Nirmalendu Prakash, Michael Lan, Abir Harrasse, Amirali Abdullah
+            year: 2025
+            venue: arXiv (accepted to ICML 2025)
+            kind: paper_preprint
+          - title: Steering Large Language Model Activations in Sparse Spaces
+            url: https://arxiv.org/abs/2503.00177
+            authors: Reza Bayat, Ali Rahimi-Kalahroudi, Mohammad Pezeshki, Sarath Chandar, Pascal Vincent
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Enhancing Multiple Dimensions of Trustworthiness in LLMs via Sparse Activation Control
+            url: https://arxiv.org/abs/2411.02461
+            authors: Yuxin Xiao, Chaoqun Wan, Yonggang Zhang, Wenxiao Wang, Binbin Lin, Xiaofei He, Xu Shen, Jieping Ye
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: Robustly Improving LLM Fairness in Realistic Settings via Interpretability
+            url: https://arxiv.org/abs/2506.10922
+            authors: Adam Karvonen, Samuel Marks
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "HyperSteer: Activation Steering at Scale with Hypernetworks"
+            url: https://arxiv.org/abs/2506.03292
+            authors: Jiuding Sun, Sidharth Baskaran, Zhengxuan Wu, Michael Sklar, Christopher Potts, Atticus Geiger
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Steering Evaluation-Aware Language Models to Act Like They Are Deployed
+            url: https://arxiv.org/abs/2510.20487
+            authors: Tim Tian Hua, Andrew Qin, Samuel Marks, Neel Nanda
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Steering Out-of-Distribution Generalization with Concept Ablation Fine-Tuning
+            url: https://arxiv.org/abs/2507.16795
+            authors: Helena Casademunt, Caden Juang, Adam Karvonen, Samuel Marks, Senthooran Rajamanoharan, Neel Nanda
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Improving Steering Vectors by Targeting Sparse Autoencoder Features
+            url: https://arxiv.org/abs/2411.02193
+            authors: Sviatoslav Chalnev, Matthew Siu, Arthur Conmy
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: Understanding Reasoning in Thinking Language Models via Steering Vectors
+            url: https://arxiv.org/abs/2506.18167
+            authors: Constantin Venhoff, Iván Arcuschin, Philip Torr, Arthur Conmy, Neel Nanda
+            year: 2025
+            venue: ICLR 2025 Workshop on Reasoning and Planning for Large Language Models
+            kind: paper_preprint
+          - title: Comparing Bottom-Up and Top-Down Steering Approaches on In-Context Learning Tasks
+            url: https://arxiv.org/abs/2411.07213
+            authors: Madeline Brumley, Joe Kwon, David Krueger, Dmitrii Krasheninnikov, Usman Anwar
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: Taxonomy, Opportunities, and Challenges of Representation Engineering for Large Language Models
+            url: https://arxiv.org/abs/2502.19649
+            authors: Jan Wehner, Sahar Abdelnabi, Daniel Tan, David Krueger, Mario Fritz
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Do safety-relevant LLM steering vectors optimized on a single example generalize?
+            url: https://lesswrong.com/posts/6aXe9nipTgwK5LxaP/do-safety-relevant-llm-steering-vectors-optimized-on-a
+            authors: Jacob Dunefsky
+            year: 2025
+            venue: arXiv
+            kind: lesswrong
+          - title: One-shot steering vectors cause emergent misalignment, too
+            url: https://lesswrong.com/posts/kcKnKHTHycHeRhcHF/one-shot-steering-vectors-cause-emergent-misalignment-too
+            authors: Jacob Dunefsky
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+      - id: learning_dev_interp
+        name: Developmental interpretability
+        summary: >-
+          Builds tools for detecting, locating, and interpreting key structural shifts, phase transitions, and emergent
+          phenomena (like grokking or deception) that occur during a model's training and in-context learning phases.
+        theoryOfChange: >-
+          Structures forming in neural networks leave identifiable traces that can be interpreted (e.g., using concepts
+          from Singular Learning Theory); by catching and analyzing these developmental moments, researchers can
+          automate interpretability, predict when dangerous capabilities emerge, and intervene to prevent deceptiveness
+          or misaligned values as early as possible.
+        seeAlso: >-
+          a:interp_fundamental, a:interp_sparse_coding, [ICL
+          transience](https://proceedings.mlr.press/v267/singh25c.html)
         orthodoxProblems:
           - "4"
-          - "7"
-        targetCase: mixed
+        targetCase: worst-case
+        broadApproaches:
+          - cognitive
+        someNames:
+          - timaeus
+          - jesse-hoogland
+          - george-wang
+          - daniel-murfet
+          - stan-van-wingerden
+          - alexander-gietelink-oldenziel
+        estimatedFTEs: 10-50
+        critiques:
+          - >-
+            [Vaintrob](https://www.lesswrong.com/posts/M2bs6xCbmc79nwr8j/dmitry-vaintrob-s-shortform#A8Ziwhts35dgqbz52),
+            [Joar Skalse
+            (2023)](https://www.alignmentforum.org/posts/ALJYj4PpkqyseL7kZ/my-criticism-of-singular-learning-theory)
+        papers:
+          - title: A Review of Developmental Interpretability in Large Language Models
+            url: https://arxiv.org/abs/2508.15841
+            authors: Ihor Kendiukhov
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Learning Coefficients, Fractals, and Trees in Parameter Space
+            url: https://openreview.net/forum?id=KUFH0n1BIM
+            authors: Max Hennick, Matthias Dellago
+            year: 2025
+            venue: ODYSSEY 2025 Conference
+            kind: paper_preprint
+          - title: Programs as Singularities
+            url: https://openreview.net/forum?id=Td37oOfmmz
+            authors: Daniel Murfet, William Troiani
+            year: 2025
+            venue: ODYSSEY 2025 Conference
+            kind: paper_preprint
+          - title: "From SLT to AIT: NN Generalisation Out of Distribution"
+            url: https://www.lesswrong.com/posts/2MX2bXreTtntB85Zy/from-slt-to-ait-nn-generalisation-out-of-distribution
+            venue: LessWrong
+            kind: error_detected
+          - title: Understanding and Controlling LLM Generalization
+            url: https://www.lesswrong.com/posts/ZSQaT2yxNNZ3eLxRd/understanding-and-controlling-llm-generalization
+            authors: Daniel Tan
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: "Programming by Backprop: LLMs Acquire Reusable Algorithmic Abstractions During Code Training"
+            url: https://arxiv.org/abs/2506.18777
+            authors: Jonathan Cook, Silvia Sapora, Arash Ahmadian, Akbir Khan, Tim Rocktaschel, Jakob Foerster, Laura Ruis
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: >-
+              Crosscoding Through Time: Tracking Emergence & Consolidation Of Linguistic Representations Throughout LLM
+              Pretraining
+            url: https://arxiv.org/abs/2509.05291
+            authors: Deniz Bayazit, Aaron Mueller, Antoine Bosselut
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Dynamics of Transient Structure in In-Context Linear Regression Transformers
+            url: https://arxiv.org/abs/2501.17745
+            authors: Liam Carroll, Jesse Hoogland, Matthew Farrugia-Roberts, Daniel Murfet
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Emergence of Superposition: Unveiling the Training Dynamics of Chain of Continuous Thought"
+            url: https://arxiv.org/abs/2509.23365
+            authors: Hanlin Zhu, Shibo Hao, Zhiting Hu, Jiantao Jiao, Stuart Russell, Yuandong Tian
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: What Do Learning Dynamics Reveal About Generalization in LLM Reasoning?
+            url: https://arxiv.org/abs/2411.07681
+            authors: Katie Kang, Amrith Setlur, Dibya Ghosh, Jacob Steinhardt, Claire Tomlin, Sergey Levine, Aviral Kumar
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Compressibility Measures Complexity: Minimum Description Length Meets Singular Learning Theory"
+            url: https://arxiv.org/abs/2510.12077
+            authors: Einar Urdshals, Edmund Lau, Jesse Hoogland, Stan van Wingerden, Daniel Murfet
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Modes of Sequence Models and Learning Coefficients
+            url: https://arxiv.org/abs/2504.18048
+            authors: Zhongtian Chen, Daniel Murfet
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: SLT for AI Safety
+            url: https://lesswrong.com/posts/J7CyENFYXPxXQpsnD/slt-for-ai-safety
+            authors: Jesse Hoogland
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: Selective regularization for alignment-focused representation engineering
+            url: https://lesswrong.com/posts/HFcriD29cw3E5QLCR/selective-regularization-for-alignment-focused
+            authors: Sandy Fraser
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+      - id: representation_structure
+        name: Representation structure and geometry
+        summary: >-
+          What do the representations look like? Does any simple structure underlie the beliefs of all well-trained
+          models? Can we get the semantics from this geometry?
+        theoryOfChange: >-
+          Get scalable unsupervised methods for finding structure in representations and interpreting them, then using
+          this to e.g. guide training.
+        seeAlso: >-
+          a:interp_concept_based, computational mechanics, feature universality, a:natural_abstractions,
+          a:interp_causal_abstractions
+        orthodoxProblems:
+          - "4"
+        broadApproaches:
+          - cognitive
         someNames:
           - simplex
           - insight-interaction-lab
@@ -1724,481 +2778,1865 @@ sections:
           - blake-richards
           - mateusz-piotrowski
         estimatedFTEs: 10-50
-        critiques:
-          - "[Vaintrob](https://www.lesswrong.com/posts/M2bs6xCbmc79nwr8j/dmitry-vaintrob-s-shortform#A8Ziwhts35dgqbz52)"
+        papers:
+          - title: Shared Global and Local Geometry of Language Model Embeddings
+            url: https://arxiv.org/abs/2503.21073
+            authors: Andrew Lee, Melanie Weber, Fernanda Viégas, Martin Wattenberg
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Connecting Neural Models Latent Geometries with Relative Geodesic Representations
+            url: https://arxiv.org/abs/2506.01599
+            authors: Hanlin Yu, Berfin Inal, Georgios Arvanitidis, Soren Hauberg, Francesco Locatello, Marco Fumero
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Constrained belief updates explain geometric structures in transformer representations
+            url: https://arxiv.org/abs/2502.01954
+            authors: Mateusz Piotrowski, Paul M. Riechers, Daniel Filan, Adam S. Shai
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: The Geometry of Self-Verification in a Task-Specific Reasoning Model
+            url: https://arxiv.org/pdf/2504.14379
+            authors: Andrew Lee, Lihao Sun, Chris Wendler, Fernanda Viégas, Martin Wattenberg
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Navigating the Latent Space Dynamics of Neural Models
+            url: https://arxiv.org/abs/2505.22785
+            authors: Marco Fumero, Luca Moschella, Emanuele Rodolà, Francesco Locatello
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "The Geometry of Refusal in Large Language Models: Concept Cones and Representational Independence"
+            url: https://arxiv.org/abs/2502.17420
+            authors: >-
+              Tom Wollschläger, Jannes Elstner, Simon Geisler, Vincent Cohen-Addad, Stephan Günnemann, Johannes
+              Gasteiger
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: The Geometry of ReLU Networks through the ReLU Transition Graph
+            url: https://arxiv.org/abs/2505.11692
+            authors: Sahil Rajesh Dhayalkar
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Deep sequence models tend to memorize geometrically; it is unclear why
+            url: https://arxiv.org/abs/2510.26745
+            authors: Shahriar Noroozizadeh, Vaishnavh Nagarajan, Elan Rosenfeld, Sanjiv Kumar
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Tracing the Representation Geometry of Language Models from Pretraining to Post-training
+            url: https://arxiv.org/abs/2509.23024
+            authors: >-
+              Melody Zixuan Li, Kumar Krishna Agrawal, Arna Ghosh, Komal Kumar Teru, Adam Santoro, Guillaume Lajoie,
+              Blake A. Richards
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Next-token pretraining implies in-context learning
+            url: https://arxiv.org/abs/2505.18373
+            authors: Paul M. Riechers, Henry R. Bigelow, Eric A. Alt, Adam Shai
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Neural networks leverage nominally quantum and post-quantum representations
+            url: https://arxiv.org/abs/2507.07432
+            authors: Paul M. Riechers, Thomas J. Elliott, Adam S. Shai
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Rank-1 LoRAs Encode Interpretable Reasoning Signals
+            url: http://arxiv.org/abs/2511.06739
+            authors: Jake Ward, Paul Riechers, Adam Shai
+            year: 2025
+            venue: "arXiv (NeurIPS 2025 Workshop: Mechanistic Interpretability Workshop)"
+            kind: paper_preprint
+          - title: Embryology of a Language Model
+            url: https://arxiv.org/abs/2508.00331
+            authors: George Wang, Garrett Baker, Andrew Gordon, Daniel Murfet
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+      - id: human_biases
+        name: Human inductive biases
+        summary: >-
+          Discover connections deep learning AI systems have with human brains and human learning processes. Develop an
+          'alignment moonshot' based on a coherent theory of learning which applies to both humans and AI systems.
+        theoryOfChange: >-
+          Humans learn trust, honesty, self-maintenance, and corrigibility; if we understand how they do maybe we can
+          get future AI systems to learn them.
+        seeAlso: active learning, ACS research
+        orthodoxProblems:
+          - "4"
+        targetCase: pessimistic
         broadApproaches:
           - cognitive
-        resources:
-          - title: DevInterp
-            url: https://devinterp.com/
-          - title: Timaeus
-            url: https://timaeus.co/
-          - title: Singular Learning Theory
-            url: https://singularlearningtheory.com/
-      - id: human-inductive-biases
-        name: Human Inductive Biases
-        keywords:
-          - rlhf
-          - corrigibility
-          - abstractions
+        someNames:
+          - lukas-muttenthaler
+          - quentin-delfosse
+        estimatedFTEs: "4"
         papers:
           - title: Aligning machine and human visual representations across abstraction levels
             url: https://www.nature.com/articles/s41586-025-09631-6
           - title: "Beginning with You: Perceptual-Initialization Improves Vision-Language Representation and Alignment"
             url: https://arxiv.org/abs/2505.14204
+            authors: Yang Hu, Runchen Wang, Stephen Chong Zhao, Xuhui Zhan, Do Hun Kim, Mark Wallace, David A. Tovar
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
           - title: Deep Reinforcement Learning Agents are not even close to Human Intelligence
             url: https://arxiv.org/html/2505.21731v1
           - title: "Teaching AI to Handle Exceptions: Supervised Fine-tuning with Human-aligned Judgment"
             url: https://arxiv.org/html/2503.02976v2#S3
+            authors: Matthew DosSantos DiSorbo, Harang Ju, Sinan Aral
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
           - title: HIBP Human Inductive Bias Project Plan
             url: https://docs.google.com/document/d/1fl7LE8AN7mLJ6uFcPuFCzatp0zCIYvjRIjQRgHPAkSE/edit?tab=t.0
-        summary: Discover connections deep learning AI systems have with human brains and human learning processes. Develop an ‘alignment moonshot’ based on a coherent theory of learning which applies to both humans and AI systems.
-        theoryOfChange: Humans learn trust, honesty, self-maintenance, and corrigibility; if we understand how they do maybe we can get future AI systems to learn them.
-        seeAlso: active learning, ACS
+            authors: Félix Dorn
+            venue: Google Docs
+            kind: error_detected
+      - id: interp_fundamental
+        name: Reverse engineering
+        summary: >-
+          Decompose a model into its functional, interacting components (circuits), formally describe what computation
+          those components perform, and validate their causal effects to reverse-engineer the model's internal
+          algorithm.
+        theoryOfChange: >-
+          By gaining a mechanical understanding of how a model works (the "circuit diagram"), we can predict how models
+          will act in novel situations (generalization), and gain the mechanistic knowledge necessary to safely modify
+          an AI's goals or internal mechanisms.
+        seeAlso: >-
+          [ambitious mech
+          interp](https://www.alignmentforum.org/posts/Hy6PX43HGgmfiTaKu/an-ambitious-vision-for-interpretability)
         orthodoxProblems:
           - "4"
-        targetCase: pessimistic
-        someNames:
-          - lukas-muttenthaler
-          - quentin-delfosse
-        estimatedFTEs: "4"
-        fundedBy:
-          - google-deepmind
+        targetCase: worst-case
         broadApproaches:
           - cognitive
-  - id: safety-by-construction
-    name: Safety by construction
-    description: Make new systems which are easier to understand and control
-    agendas:
-      - id: guaranteed-safe-ai
-        name: Guaranteed Safe AI
-        lesswrongTags:
-          - guaranteed-safe-ai
-        keywords:
-          - formal-verification
-          - world-models
-          - safety-cases
+        someNames:
+          - lucius-bushnaq
+          - dan-braun
+          - lee-sharkey
+          - aaron-mueller
+          - atticus-geiger
+          - sheridan-feucht
+          - david-bau
+          - yonatan-belinkov
+          - stefan-heimersheim
+        estimatedFTEs: 100-200
+        critiques:
+          - >-
+            [Interpretability Will Not Reliably Find Deceptive
+            AI](https://www.alignmentforum.org/posts/PwnadG4BFjaER3MGf/interpretability-will-not-reliably-find-deceptive-ai),
+            [A Problem to Solve Before Building a Deception
+            Detector](https://www.lesswrong.com/posts/YXNeA3RyRrrRWS37A/a-problem-to-solve-before-building-a-deception-detector),
+            [MoSSAIC: AI Safety After Mechanism](https://openreview.net/forum?id=n7WYSJ35FU), [The Misguided Quest for
+            Mechanistic AI
+            Interpretability](https://ai-frontiers.org/articles/the-misguided-quest-for-mechanistic-ai-interpretability).
+            [Mechanistic?](https://arxiv.org/abs/2410.09087), [Assessing skeptical views of interpretability
+            research](https://www.youtube.com/watch?v=woo_J0RKcpQ),  [Activation space interpretability may be
+            doomed](https://www.lesswrong.com/posts/gYfpPbww3wQRaxAFD/activation-space-interpretability-may-be-doomed),
+            [A Pragmatic Vision for
+            Interpretability](https://www.alignmentforum.org/posts/StENzDcD3kpfGJssR/a-pragmatic-vision-for-interpretability)
         papers:
-          - title: "SafePlanBench: evaluating a Guaranteed Safe AI Approach for LLM-based Agents"
-            url: https://manifund.org/projects/safeplanbench-evaluating-a-guaranteed-safe-ai-approach-for-llm-based-agents
-            authors: Agustín Martinez Suñé, Tan Zhi Xuan
-          - title: Report on NSF Workshop on Science of Safe AI
-            url: https://arxiv.org/abs/2506.22492
-          - title: "A benchmark for vericoding: formally verified program synthesis"
-            url: https://arxiv.org/abs/2509.22908
-          - title: Beliefs about formal methods and AI safety
-            url: https://lesswrong.com/posts/CCT7Qc8rSeRs7r5GL/beliefs-about-formal-methods-and-ai-safety
-          - title: A Toolchain for AI-Assisted Code Specification, Synthesis and Verification
-            url: https://atlascomputing.org/ai-assisted-fv-toolchain.pdf
-        summary: Formally model the behavior of cyber-physical systems, construct formally verified shells and interfaces which pose precise constraints on what actions can occur, and require AIs to provide safety guarantees for their recommended actions (correctness and uniqueness)
-        theoryOfChange: Make a formal verification system that can act as an intermediary between human users and a potentially dangerous system, only letting provably safe actions through. (Notable for not requiring that we solve ELK; does require that we solve ontology though)
-        seeAlso: "[Synthesizing Standalone World-Models](https://www.alignmentforum.org/posts/LngR93YwiEpJ3kiWh/research-agenda-synthesizing-standalone-world-models)*,* Bengio's Scientist AI*,* Safeguarded AI, Open Agency Architecture, SLES, program synthesis"
+          - title: "The Circuits Research Landscape: Results and Perspectives"
+            url: https://www.neuronpedia.org/graph/info
+            authors: >-
+              Jack Lindsey, Emmanuel Ameisen, Neel Nanda, Stepan Shabalin, Mateusz Piotrowski, Tom McGrath, Michael
+              Hanna, Owen Lewis, Curt Tigges, Jack Merullo, Connor Watts, Gonçalo Paulo, Joshua Batson, Liv Gorton,
+              Elana Simon, Max Loeffler, Callum McDougall, Johnny Lin
+            year: 2025
+            venue: Neuronpedia
+            kind: blog_post
+          - title: Stochastic Parameter Decomposition
+            url: https://openreview.net/forum?id=dEdS9ao8gN
+            authors: Dan Braun, Lucius Bushnaq, Lee Sharkey
+            year: 2025
+            venue: ODYSSEY 2025 Conference
+            kind: paper_preprint
+          - title: "MIB: A Mechanistic Interpretability Benchmark"
+            url: https://arxiv.org/abs/2504.13151
+            authors: >-
+              Aaron Mueller, Atticus Geiger, Sarah Wiegreffe, Dana Arad, Iván Arcuschin, Adam Belfki, Yik Siu Chan,
+              Jaden Fiotto-Kaufman, Tal Haklay, Michael Hanna, Jing Huang, Rohan Gupta, Yaniv Nikankin, Hadas Orgad,
+              Nikhil Prakash, Anja Reusch, Aruna Sankaranarayanan, Shun Shao, Alessandro Stolfo, Martin Tutek, Amir Zur,
+              David Bau, Yonatan Belinkov
+            year: 2025
+            venue: ICML 2025
+            kind: paper_preprint
+          - title: "Circuits in Superposition: Compressing many small neural networks into one"
+            url: https://www.lesswrong.com/posts/roE7SHjFWEoMcGZKd/circuits-in-superposition-compressing-many-small-neural
+            authors: Lucius Bushnaq, jake_mendel
+            year: 2024
+            venue: LessWrong
+            kind: lesswrong
+          - title: "Error: Content Unavailable (429: Too Many Requests)"
+            url: https://www.lesswrong.com/posts/ZxFchCFJFcgysYsT9/compressed-computation-is-probably-not-computation-in
+            venue: LessWrong
+            kind: error_detected
+          - title: The Dual-Route Model of Induction
+            url: https://arxiv.org/abs/2504.03022
+            authors: Sheridan Feucht, Eric Todd, Byron Wallace, David Bau
+            year: 2025
+            venue: COLM 2025
+            kind: paper_published
+          - title: The Geometry of Self-Verification in a Task-Specific Reasoning Model
+            url: https://arxiv.org/abs/2504.14379
+            authors: Andrew Lee, Lihao Sun, Chris Wendler, Fernanda Viégas, Martin Wattenberg
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Converting MLPs into Polynomials in Closed Form
+            url: https://arxiv.org/abs/2502.01032
+            authors: Nora Belrose, Alice Rigg
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Extractive Structures Learned in Pretraining Enable Generalization on Finetuned Facts
+            url: https://arxiv.org/abs/2412.04614
+            authors: Jiahai Feng, Stuart Russell, Jacob Steinhardt
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: Identifying Sparsely Active Circuits Through Local Loss Landscape Decomposition
+            url: https://arxiv.org/abs/2504.00194
+            authors: Brianna Chrisman, Lucius Bushnaq, Lee Sharkey
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Blink of an eye: a simple theory for feature localization in generative models"
+            url: https://arxiv.org/abs/2502.00921
+            authors: Marvin Li, Aayush Karan, Sitan Chen
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: From Memorization to Reasoning in the Spectrum of Loss Curvature
+            url: https://arxiv.org/abs/2510.24256
+            authors: Jack Merullo, Srihita Vatsavaya, Lucius Bushnaq, Owen Lewis
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Generalization or Hallucination? Understanding Out-of-Context Reasoning in Transformers
+            url: https://arxiv.org/abs/2506.10887
+            authors: >-
+              Yixiao Huang, Hanlin Zhu, Tianyu Guo, Jiantao Jiao, Somayeh Sojoudi, Michael I. Jordan, Stuart Russell,
+              Song Mei
+            year: 2025
+            venue: NeurIPS 2025
+            kind: paper_preprint
+          - title: "RelP: Faithful and Efficient Circuit Discovery in Language Models via Relevance Patching"
+            url: https://arxiv.org/abs/2508.21258
+            authors: Farnoush Rezaei Jafari, Oliver Eberle, Ashkan Khakzar, Neel Nanda
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Structural Inference: Interpreting Small Language Models with Susceptibilities"
+            url: https://arxiv.org/abs/2504.18274
+            authors: Garrett Baker, George Wang, Jesse Hoogland, Daniel Murfet
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: >-
+              Interpretability in Parameter Space: Minimizing Mechanistic Description Length with Attribution-based
+              Parameter Decomposition
+            url: https://arxiv.org/abs/2501.14926
+            authors: Dan Braun, Lucius Bushnaq, Stefan Heimersheim, Jake Mendel, Lee Sharkey
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: How Do LLMs Perform Two-Hop Reasoning in Context?
+            url: https://arxiv.org/abs/2502.13913
+            authors: Tianyu Guo, Hanlin Zhu, Ruiqi Zhang, Jiantao Jiao, Song Mei, Michael I. Jordan, Stuart Russell
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "On the creation of narrow AI: hierarchy and nonlocality of neural network skills"
+            url: https://arxiv.org/abs/2505.15811
+            authors: Eric J. Michaud, Asher Parker-Sartori, Max Tegmark
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Fresh in memory: Training-order recency is linearly encoded in language model activations"
+            url: https://arxiv.org/abs/2509.14223
+            authors: Dmitrii Krasheninnikov, Richard E. Turner, David Krueger
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Language Models use Lookbacks to Track Beliefs
+            url: https://arxiv.org/abs/2505.14685
+            authors: >-
+              Nikhil Prakash, Natalie Shapira, Arnab Sen Sharma, Christoph Riedl, Yonatan Belinkov, Tamar Rott Shaham,
+              David Bau, Atticus Geiger
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Interpreting Emergent Planning in Model-Free Reinforcement Learning
+            url: https://arxiv.org/pdf/2504.01871
+            authors: Thomas Bush, Stephen Chung, Usman Anwar, Adrià Garriga-Alonso, David Krueger
+            year: 2025
+            venue: arXiv (ICLR 2025 oral)
+            kind: paper_preprint
+          - title: Constrained belief updates explain geometric structures in transformer representations
+            url: https://arxiv.org/abs/2502.01954
+            authors: Mateusz Piotrowski, Paul M. Riechers, Daniel Filan, Adam S. Shai
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Do Language Models Use Their Depth Efficiently?
+            url: https://arxiv.org/abs/2505.13898
+            authors: Róbert Csordás, Christopher D. Manning, Christopher Potts
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: How Do Transformers Learn Variable Binding in Symbolic Programs?
+            url: https://arxiv.org/abs/2505.20896
+            authors: Yiwei Wu, Atticus Geiger, Raphaël Millière
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: LLMs Process Lists With General Filter Heads
+            url: https://arxiv.org/abs/2510.26784
+            authors: Arnab Sen Sharma, Giordano Rogers, Natalie Shapira, David Bau
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Language Models Use Trigonometry to Do Addition
+            url: https://arxiv.org/abs/2502.00873
+            authors: Subhash Kantamneni, Max Tegmark
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Transformers Struggle to Learn to Search
+            url: https://arxiv.org/abs/2412.04703
+            authors: >-
+              Abulhair Saparov, Srushti Pawar, Shreyas Pimpalgaonkar, Nitish Joshi, Richard Yuanzhe Pang, Vishakh
+              Padmakumar, Seyed Mehran Kazemi, Najoung Kim, He He
+            year: 2024
+            venue: ICLR 2025
+            kind: paper_preprint
+          - title: "ICLR: In-Context Learning of Representations"
+            url: https://openreview.net/forum?id=pXlmOmlHJZ
+            authors: >-
+              Core Francisco Park, Andrew Lee, Ekdeep Singh Lubana, Yongyi Yang, Maya Okawa, Kento Nishi, Martin
+              Wattenberg, Hidenori Tanaka
+            year: 2025
+            venue: ICLR 2025
+            kind: paper_published
+          - title: Adversarial Examples Are Not Bugs, They Are Superposition
+            url: https://arxiv.org/abs/2508.17456
+            authors: Liv Gorton, Owen Lewis
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Building and evaluating alignment auditing agents
+            url: https://lesswrong.com/posts/DJAZHYjWxMrcd2na3/building-and-evaluating-alignment-auditing-agents
+            authors: Sam Marks, trentbrick, RowanWang, Sam Bowman, Euan Ong, Johannes Treutlein, evhub
+            year: 2025
+            venue: LessWrong / AI Alignment Forum
+            kind: lesswrong
+          - title: Bridging the human–AI knowledge gap through concept discovery and transfer in AlphaZero
+            url: https://www.pnas.org/doi/10.1073/pnas.2406675122
+          - title: "Interpreting learned search: finding a transition model and value function in an RNN that plays Sokoban"
+            url: https://arxiv.org/abs/2506.10138
+            authors: Mohammad Taufeeque, Aaron David Tucker, Adam Gleave, Adrià Garriga-Alonso
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+      - id: interp_concept_based
+        name: Concept-based interpretability
+        summary: >-
+          Identifies directions or subspaces in a model's latent state that correspond to high-level concepts (like
+          refusal, deception, or planning) and uses them to build "mind-reading" probes that audit models for
+          misalignment or monitor them at runtime.
+        theoryOfChange: >-
+          By mapping internal activations to human-interpretable concepts, we can detect dangerous capabilities or
+          deceptive alignment directly in the mind of the model even if its overt behavior is perfectly safe. Deploy
+          computationally cheap monitors to flag some hidden misalignment in deployed systems.
+        seeAlso: a:interp_fundamental, a:interp_sparse_coding, a:model_diff
         orthodoxProblems:
           - "1"
           - "4"
-          - "7"
-          - "9"
-          - "12"
-        targetCase: (nearly) worst-case
+        targetCase: pessimistic
+        broadApproaches:
+          - cognitive
+        someNames:
+          - daniel-beaglehole
+          - adityanarayanan-radhakrishnan
+          - enric-boix-adser
+          - tom-wollschlger
+          - anna-soligo
+          - jack-lindsey
+          - brian-christian
+          - ling-hu
+          - nicholas-goldowsky-dill
+        estimatedFTEs: 50-100
+        critiques:
+          - >-
+            [Exploring the generalization of LLM truth directions on conversational
+            formats](https://arxiv.org/html/2505.09807v1), [Understanding (Un)Reliability of Steering Vectors in
+            Language Models](https://arxiv.org/abs/2505.22637)
+        papers:
+          - title: Toward universal steering and monitoring of AI models
+            url: https://arxiv.org/abs/2502.03708
+            authors: Daniel Beaglehole, Adityanarayanan Radhakrishnan, Enric Boix-Adserà, Mikhail Belkin
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Convergent Linear Representations of Emergent Misalignment
+            url: https://arxiv.org/abs/2506.11618
+            authors: Anna Soligo, Edward Turner, Senthooran Rajamanoharan, Neel Nanda
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Detecting Strategic Deception Using Linear Probes
+            url: https://arxiv.org/abs/2502.03407
+            authors: Nicholas Goldowsky-Dill, Bilal Chughtai, Stefan Heimersheim, Marius Hobbhahn
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Auditing language models for hidden objectives
+            url: https://www.anthropic.com/research/auditing-hidden-objectives
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Reward Model Interpretability via Optimal and Pessimal Tokens
+            url: https://arxiv.org/abs/2506.07326
+            authors: Brian Christian, Hannah Rose Kirk, Jessica A.F. Thompson, Christopher Summerfield, Tsvetomira Dumbalska
+            year: 2025
+            venue: FAccT '25 (ACM Conference on Fairness, Accountability, and Transparency)
+            kind: paper_preprint
+          - title: "The Geometry of Refusal in Large Language Models: Concept Cones and Representational Independence"
+            url: https://arxiv.org/abs/2502.17420
+            authors: >-
+              Tom Wollschläger, Jannes Elstner, Simon Geisler, Vincent Cohen-Addad, Stephan Günnemann, Johannes
+              Gasteiger
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: How Do LLMs Persuade? Linear Probes Can Uncover Persuasion Dynamics in Multi-Turn Conversations
+            url: https://arxiv.org/abs/2508.05625
+            authors: Brandon Jaipersaud, David Krueger, Ekdeep Singh Lubana
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Refusal in LLMs is an Affine Function
+            url: https://arxiv.org/abs/2411.09003
+            authors: Thomas Marshall, Adam Scherlis, Nora Belrose
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: Here's 18 Applications of Deception Probes
+            url: https://lesswrong.com/posts/7zhAwcBri7yupStKy/here-s-18-applications-of-deception-probes
+            authors: Cleo Nardo, Avi Parrack, jordine
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: White Box Control at UK AISI - Update on Sandbagging Investigations
+            url: https://www.alignmentforum.org/posts/pPEeMdgjpjHZWCDFw/white-box-control-at-uk-aisi-update-on-sandbagging
+            authors: >-
+              Joseph Bloom, Jordan Taylor, Connor Kissane, Sid Black, merizian, alexdzm, jacoba, Ben Millwood, Alan
+              Cooney
+            year: 2025
+            venue: AI Alignment Forum
+            kind: lesswrong
+          - title: Cost-Effective Constitutional Classifiers via Representation Re-use
+            url: https://alignment.anthropic.com/2025/cheap-monitors
+            authors: >-
+              Hoagy Cunningham, Alwin Peng, Jerry Wei, Euan Ong, Fabien Roger, Linda Petrini, Misha Wagner, Vladimir
+              Mikulik, Mrinank Sharma
+            year: 2025
+            venue: Anthropic Alignment Science Blog
+            kind: blog_post
+      - id: deception_detectors
+        name: Lie and deception detectors
+        summary: >-
+          Detect when a model is being deceptive or lying by building white- or black-box detectors. Some work below
+          requires intent in their definition, while other work focuses only on whether the model states something it
+          believes to be false, regardless of intent.
+        theoryOfChange: >-
+          Such detectors could flag suspicious behavior during evaluations or deployment, augment training to reduce
+          deception, or audit models pre-deployment. Specific applications include alignment evaluations (e.g. by
+          validating answers to introspective questions), safeguarding evaluations (catching models that "sandbag", that
+          is, strategically underperform to pass capability tests), and large-scale deployment monitoring. An honest
+          version of a model could also provide oversight during training or detect cases where a model behaves in ways
+          it understands are unsafe.
+        seeAlso: a:interp_fundamental, a:ai_deception, a:evals_sandbagging
+        targetCase: pessimistic
+        broadApproaches:
+          - cognitive
+        someNames:
+          - cadenzahttpscadenzalabsorg
+          - sam-marks
+          - rowan-wang
+          - kieron-kretschmar
+          - sharan-maiya
+          - walter-laurito
+          - chris-cundy
+          - adam-gleave
+          - aviel-parrack
+          - stefan-heimersheim
+          - carlo-attubato
+          - joseph-bloom
+          - jordan-taylor
+          - alex-mckenzie
+          - urja-pawar
+          - lewis-smith
+          - bilal-chughtai
+          - neel-nanda
+        estimatedFTEs: 10-50
+        critiques:
+          - >-
+            difficult to determine if behavior is strategic deception or only low level "reflexive" actions; Unclear if
+            a model roleplaying a liar has deceptive intent. [How are intentional descriptions (like deception) related
+            to algorithmic ones (like understanding the mechanisms models
+            use)?](https://www.lesswrong.com/posts/YXNeA3RyRrrRWS37A/a-problem-to-solve-before-building-a-deception-detector),
+            [Is This Lie Detector Really Just a Lie Detector? An Investigation of LLM Probe
+            Specificity](https://www.lesswrong.com/posts/5dkhdRMypeuyoXfmb/is-this-lie-detector-really-just-a-lie-detector-an),[Herrmann](https://www.lesswrong.com/posts/bCQbSFrnnAk7CJNpM/still-no-lie-detector-for-llms),
+            [Smith and Chughtai](https://arxiv.org/abs/2511.22662)
+        papers:
+          - title: "Caught in the Act: a mechanistic approach to detecting deception"
+            url: https://arxiv.org/abs/2508.19505
+            authors: Gerard Boxo, Ryan Socha, Daniel Yoo, Shivam Raval
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Detecting Strategic Deception Using Linear Probes
+            url: https://www.lesswrong.com/posts/9pGbTz6c78PGwJein/detecting-strategic-deception-using-linear-probes
+            authors: Nicholas Goldowsky-Dill, Bilal Chughtai, Stefan Heimersheim, Marius Hobbhahn
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Detecting High-Stakes Interactions with Activation Probes
+            url: https://arxiv.org/abs/2506.10805
+            authors: >-
+              Alex McKenzie, Urja Pawar, Phil Blandfort, William Bankes, David Krueger, Ekdeep Singh Lubana, Dmitrii
+              Krasheninnikov
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: White Box Control at UK AISI - Update on Sandbagging Investigations
+            url: https://www.lesswrong.com/posts/pPEeMdgjpjHZWCDFw/white-box-control-at-uk-aisi-update-on-sandbagging
+            authors: >-
+              Joseph Bloom, Jordan Taylor, Connor Kissane, Sid Black, Jacob Merizian, Alex Zelenka-Martin, Jacob Arbeid,
+              Ben Millwood, Alan Cooney
+            year: 2025
+            venue: LessWrong / AI Alignment Forum
+            kind: lesswrong
+          - title: White Box Control at UK AISI - Update on Sandbagging Investigations
+            url: https://www.alignmentforum.org/posts/pPEeMdgjpjHZWCDFw/white-box-control-at-uk-aisi-update-on-sandbagging
+            authors: >-
+              Joseph Bloom, Jordan Taylor, Connor Kissane, Sid Black, merizian, alexdzm, jacoba, Ben Millwood, Alan
+              Cooney
+            year: 2025
+            venue: AI Alignment Forum
+            kind: lesswrong
+          - title: Trusted monitoring, but with deception probes.
+            url: https://www.lesswrong.com/posts/eaEqAzGN3uJfpfGoc/trusted-monitoring-but-with-deception-probes
+            authors: Avi Parrack, StefanHex, Cleo Nardo
+            year: 2024
+            venue: LessWrong
+            kind: lesswrong
+          - title: "Among Us: A Sandbox for Agentic Deception"
+            url: https://www.lesswrong.com/posts/gRc8KL2HLtKkFmNPr/among-us-a-sandbox-for-agentic-deception
+            venue: LessWrong
+            kind: blocked
+          - title: Here's 18 Applications of Deception Probes
+            url: https://www.lesswrong.com/posts/7zhAwcBri7yupStKy/18-applications-of-deception-probes
+            authors: Cleo Nardo, Avi Parrack, jordine
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: Preference Learning with Lie Detectors can Induce Honesty or Evasion
+            url: https://arxiv.org/abs/2505.13787
+            authors: Chris Cundy, Adam Gleave
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Liars' Bench: Evaluating Lie Detectors for Language Models"
+            url: https://arxiv.org/html/2511.16035v1
+            authors: Kieron Kretschmar, Walter Laurito, Sharan Maiya, Samuel Marks
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Evaluating honesty and lie detection techniques on a diverse suite of dishonest models
+            url: https://alignment.anthropic.com/2025/honesty-elicitation/
+            authors: Rowan Wang, Johannes Treutlein, Fabien Roger, Evan Hubinger, Sam Marks
+            year: 2025
+            venue: Anthropic Alignment Science Blog
+            kind: blog_post
+      - id: model_diff
+        name: Model diffing
+        summary: >-
+          Understand what happens when a model is finetuned, what the "diff" between the finetuned and the original
+          model consists in.
+        theoryOfChange: >-
+          By identifying the mechanistic differences between a base model and its fine-tune (e.g., after RLHF), maybe we
+          can verify that safety behaviors are robustly "internalized" rather than superficially patched, and detect if
+          dangerous capabilities or deceptive alignment have been introduced without needing to re-analyze the entire
+          model. The diff is also much smaller, since most parameters don't change, which means you can use heavier
+          methods on them.
+        seeAlso: a:interp_sparse_coding, a:interp_fundamental
+        orthodoxProblems:
+          - "1"
+        targetCase: pessimistic
+        broadApproaches:
+          - cognitive
+        someNames:
+          - julian-minder
+          - clment-dumas
+          - neel-nanda
+          - trenton-bricken
+          - jack-lindsey
+        estimatedFTEs: 10-30
+        papers:
+          - title: Narrow Finetuning Leaves Clearly Readable Traces in Activation Differences
+            url: https://arxiv.org/abs/2510.13900
+            authors: Julian Minder, Clément Dumas, Stewart Slocum, Helena Casademunt, Cameron Holmes, Robert West, Neel Nanda
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Overcoming Sparsity Artifacts in Crosscoders to Interpret Chat-Tuning
+            url: https://arxiv.org/abs/2504.02922
+            authors: Julian Minder, Clément Dumas, Caden Juang, Bilal Chugtai, Neel Nanda
+            year: 2025
+            venue: NeurIPS 2025
+            kind: paper_preprint
+          - title: What We Learned Trying to Diff Base and Chat Models (And Why It Matters)
+            url: >-
+              https://www.lesswrong.com/posts/xmpauEXEerzYcJKNm/what-we-learned-trying-to-diff-base-and-chat-models-and-why
+            authors: Clément Dumas, Julian Minder, Neel Nanda
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: Persona Features Control Emergent Misalignment
+            url: https://arxiv.org/abs/2506.19823
+            authors: >-
+              Miles Wang, Tom Dupré la Tour, Olivia Watkins, Alex Makelov, Ryan A. Chi, Samuel Miserendino, Jeffrey
+              Wang, Achyuta Rajaram, Johannes Heidecke, Tejal Patwardhan, Dan Mossing
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Insights on Crosscoder Model Diffing
+            url: https://transformer-circuits.pub/2025/crosscoder-diffing-update/index.html
+            authors: >-
+              Siddharth Mishra-Sharma, Trenton Bricken, Jack Lindsey, Adam Jermyn, Jonathan Marcus, Kelley Rivoire,
+              Christopher Olah, Thomas Henighan
+            venue: Transformer Circuits Thread
+            kind: blog_post
+          - title: Open Source Replication of Anthropic's Crosscoder paper for model-diffing
+            url: >-
+              https://www.lesswrong.com/posts/srt6JXsRMtmqAJavD/open-source-replication-of-anthropic-s-crosscoder-paper-for
+            authors: Connor Kissane, robertzk, Arthur Conmy, Neel Nanda
+            year: 2024
+            venue: LessWrong
+            kind: lesswrong
+          - title: diffing-toolkit (GitHub 404 Error)
+            url: https://github.com/science-of-finetuning/diffing-toolkit%20
+            venue: GitHub
+            kind: error_detected
+          - title: "Error: Content Not Found"
+            url: https://openreview.net/forum?id=ZB84SvrZB8%20
+            venue: OpenReview
+            kind: error_detected
+          - title: Discovering Undesired Rare Behaviors via Model Diff Amplification
+            url: https://www.goodfire.ai/research/model-diff-amplification
+            authors: Santiago Aranguri, Thomas McGrath
+            year: 2025
+            venue: Goodfire Research
+            kind: blog_post
+      - id: interp_sparse_coding
+        name: Sparse Coding
+        summary: >-
+          Decompose the polysemantic activations of the residual stream into a sparse linear combination of monosemantic
+          "features" which correspond to interpretable concepts.
+        theoryOfChange: >-
+          Get a principled decomposition of an LLM's activation into atomic components → identify deception and other
+          misbehaviors.
+        seeAlso: a:interp_concept_based, a:interp_fundamental
+        orthodoxProblems:
+          - "1"
+          - "4"
+        targetCase: average-case
+        someNames:
+          - leo-gao
+          - dan-mossing
+          - emmanuel-ameisen
+          - jack-lindsey
+          - adam-pearce
+          - thomas-heap
+          - abhinav-menon
+          - kenny-peng
+          - tim-lawson
+        estimatedFTEs: 50-100
+        critiques:
+          - >-
+            [Sparse Autoencoders Can Interpret Randomly Initialized Transformers](https://arxiv.org/abs/2501.17727),
+            [The Sparse Autoencoders bubble has popped, but they are still
+            promising](https://agarriga.substack.com/p/the-sparse-autoencoders-bubble-has), [Negative Results for SAEs
+            On Downstream Tasks and Deprioritising SAE
+            Research](https://www.alignmentforum.org/posts/4uXCAJNuPKtKBsi28/), [Sparse Autoencoders Trained on the Same
+            Data Learn Different Features](https://arxiv.org/pdf/2501.16615), [Why Not Just Train For
+            Interpretability?](https://www.lesswrong.com/posts/2HbgHwdygH6yeHKKq/why-not-just-train-for-interpretability)
+        papers:
+          - title: Unknown - PDF content not accessible
+            url: https://cdn.openai.com/pdf/41df8f28-d4ef-43e9-aed2-823f9393e470/circuit-sparsity-paper.pdf
+            kind: error_detected
+          - title: "Circuit Tracing: Revealing Computational Graphs in Language Models"
+            url: https://transformer-circuits.pub/2025/attribution-graphs/methods.html
+            authors: >-
+              Emmanuel Ameisen, Jack Lindsey, Adam Pearce, Wes Gurnee, Nicholas L. Turner, Brian Chen, Craig Citro,
+              David Abrahams, Shan Carter, Basil Hosmer, Jonathan Marcus, Michael Sklar, Adly Templeton, Trenton
+              Bricken, Callum McDougall, Hoagy Cunningham, Thomas Henighan, Adam Jermyn, Andy Jones, Andrew Persic,
+              Zhenyi Qi, T. Ben Thompson, Sam Zimmerman, Kelley Rivoire, Thomas Conerly, Chris Olah, Joshua Batson
+            year: 2025
+            venue: Transformer Circuits Thread
+            kind: blog_post
+          - title: Overcoming Sparsity Artifacts in Crosscoders to Interpret Chat-Tuning
+            url: https://arxiv.org/abs/2504.02922
+            authors: Julian Minder, Clément Dumas, Caden Juang, Bilal Chugtai, Neel Nanda
+            year: 2025
+            venue: NeurIPS 2025
+            kind: paper_preprint
+          - title: Sparse Autoencoders Learn Monosemantic Features in Vision-Language Models
+            url: https://arxiv.org/abs/2504.02821
+            authors: Mateusz Pach, Shyamgopal Karthik, Quentin Bouniot, Serge Belongie, Zeynep Akata
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: >-
+              I Have Covered All the Bases Here: Interpreting Reasoning Features in Large Language Models via Sparse
+              Autoencoders
+            url: https://arxiv.org/abs/2503.18878
+            authors: >-
+              Andrey Galichin, Alexey Dontsov, Polina Druzhinina, Anton Razzhigaev, Oleg Y. Rogov, Elena Tutubalina,
+              Ivan Oseledets
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Sparse Autoencoders Do Not Find Canonical Units of Analysis
+            url: https://arxiv.org/abs/2502.04878
+            authors: >-
+              Patrick Leask, Bart Bussmann, Michael Pearce, Joseph Bloom, Curt Tigges, Noura Al Moubayed, Lee Sharkey,
+              Neel Nanda
+            year: 2025
+            venue: arXiv (accepted to ICLR 2025)
+            kind: paper_preprint
+          - title: Transcoders Beat Sparse Autoencoders for Interpretability
+            url: https://arxiv.org/abs/2501.18823
+            authors: Gonçalo Paulo, Stepan Shabalin, Nora Belrose
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: The Unintended Trade-off of AI Alignment:Balancing Hallucination Mitigation and Safety in LLMs
+            url: https://arxiv.org/abs/2510.07775
+            authors: Omar Mahmoud, Ali Khalil, Buddhika Laknath Semage, Thommen George Karimpanal, Santu Rana
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Scaling sparse feature circuit finding for in-context learning
+            url: https://arxiv.org/abs/2504.13756
+            authors: Dmitrii Kharlapenko, Stepan Shabalin, Fazl Barez, Arthur Conmy, Neel Nanda
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Learning Multi-Level Features with Matryoshka Sparse Autoencoders
+            url: https://arxiv.org/abs/2503.17547
+            authors: Bart Bussmann, Noa Nabeshima, Adam Karvonen, Neel Nanda
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Are Sparse Autoencoders Useful? A Case Study in Sparse Probing
+            url: https://arxiv.org/abs/2502.16681
+            authors: Subhash Kantamneni, Joshua Engels, Senthooran Rajamanoharan, Max Tegmark, Neel Nanda
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Sparse Autoencoders Trained on the Same Data Learn Different Features
+            url: https://arxiv.org/abs/2501.16615
+            authors: Gonçalo Paulo, Nora Belrose
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Partially Rewriting a Transformer in Natural Language
+            url: https://arxiv.org/abs/2501.18838
+            authors: Gonçalo Paulo, Nora Belrose
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "SAEBench: A Comprehensive Benchmark for Sparse Autoencoders in Language Model Interpretability"
+            url: https://arxiv.org/abs/2503.09532
+            authors: >-
+              Adam Karvonen, Can Rager, Johnny Lin, Curt Tigges, Joseph Bloom, David Chanin, Yeu-Tong Lau, Eoin Farrell,
+              Callum McDougall, Kola Ayonrinde, Demian Till, Matthew Wearden, Arthur Conmy, Samuel Marks, Neel Nanda
+            year: 2025
+            venue: arXiv (accepted to ICML 2025)
+            kind: paper_preprint
+          - title: Low-Rank Adapting Models for Sparse Autoencoders
+            url: https://arxiv.org/abs/2501.19406
+            authors: Matthew Chen, Joshua Engels, Max Tegmark
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Enhancing Automated Interpretability with Output-Centric Feature Descriptions
+            url: https://arxiv.org/abs/2501.08319
+            authors: Yoav Gur-Arieh, Roy Mayan, Chen Agassy, Atticus Geiger, Mor Geva
+            year: 2025
+            venue: arXiv (accepted to ACL 2025)
+            kind: paper_preprint
+          - title: "Towards Understanding Distilled Reasoning Models: A Representational Approach"
+            url: https://arxiv.org/abs/2503.03730
+            authors: David D. Baek, Max Tegmark
+            year: 2025
+            venue: ICLR 2025 Workshop on Building Trust in Language Models and Applications
+            kind: paper_preprint
+          - title: Do Sparse Autoencoders Generalize? A Case Study of Answerability
+            url: https://arxiv.org/abs/2502.19964
+            authors: Lovis Heindrich, Philip Torr, Fazl Barez, Veronika Thost
+            year: 2025
+            venue: ICML 2025 Workshop on Reliable and Responsible Foundation Models (arXiv preprint)
+            kind: paper_preprint
+          - title: >-
+              Large Language Models Share Representations of Latent Grammatical Concepts Across Typologically Diverse
+              Languages
+            url: https://arxiv.org/abs/2501.06346
+            authors: Jannik Brinkmann, Chris Wendler, Christian Bartelt, Aaron Mueller
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Interpreting the linear structure of vision-language model embedding spaces
+            url: https://arxiv.org/abs/2504.11695
+            authors: Isabel Papadimitriou, Huangyuan Su, Thomas Fel, Sham Kakade, Stephanie Gil
+            year: 2025
+            venue: COLM 2025
+            kind: paper_preprint
+          - title: What's In My Human Feedback? Learning Interpretable Descriptions of Preference Data
+            url: https://arxiv.org/abs/2510.26202
+            authors: Rajiv Movva, Smitha Milli, Sewon Min, Emma Pierson
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Do I Know This Entity? Knowledge Awareness and Hallucinations in Language Models
+            url: https://arxiv.org/abs/2411.14257
+            authors: Javier Ferrando, Oscar Obeso, Senthooran Rajamanoharan, Neel Nanda
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: Decomposing MLP Activations into Interpretable Features via Semi-Nonnegative Matrix Factorization
+            url: https://arxiv.org/abs/2506.10920
+            authors: Or Shafran, Atticus Geiger, Mor Geva
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Priors in Time: Missing Inductive Biases for Language Model Interpretability"
+            url: https://arxiv.org/abs/2511.01836
+            authors: >-
+              Ekdeep Singh Lubana, Can Rager, Sai Sumedh R. Hindupur, Valerie Costa, Greta Tuckute, Oam Patel, Sonia
+              Krishna Murthy, Thomas Fel, Daniel Wurgaft, Eric J. Bigelow, Johnny Lin, Demba Ba, Martin Wattenberg,
+              Fernanda Viegas, Melanie Weber, Aaron Mueller
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: >-
+              Inference-Time Decomposition of Activations (ITDA): A Scalable Approach to Interpreting Large Language
+              Models
+            url: https://arxiv.org/abs/2505.17769
+            authors: Patrick Leask, Neel Nanda, Noura Al Moubayed
+            year: 2025
+            venue: ICML 2025
+            kind: paper_preprint
+          - title: Binary Sparse Coding for Interpretability
+            url: https://arxiv.org/abs/2509.25596
+            authors: Lucia Quirke, Stepan Shabalin, Nora Belrose
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Dense SAE Latents Are Features, Not Bugs
+            url: https://arxiv.org/abs/2506.15679
+            authors: >-
+              Xiaoqing Sun, Alessandro Stolfo, Joshua Engels, Ben Wu, Senthooran Rajamanoharan, Mrinmaya Sachan, Max
+              Tegmark
+            year: 2025
+            venue: arXiv (NeurIPS 2025)
+            kind: paper_preprint
+          - title: Evaluating Sparse Autoencoders on Targeted Concept Erasure Tasks
+            url: https://arxiv.org/abs/2411.18895
+            authors: Adam Karvonen, Can Rager, Samuel Marks, Neel Nanda
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: Evaluating SAE interpretability without explanations
+            url: https://arxiv.org/abs/2507.08473
+            authors: Gonçalo Paulo, Nora Belrose
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: SAEs Are Good for Steering -- If You Select the Right Features
+            url: https://arxiv.org/abs/2505.20063
+            authors: Dana Arad, Aaron Mueller, Yonatan Belinkov
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Line of Sight: On Linear Representations in VLLMs"
+            url: https://arxiv.org/abs/2506.04706
+            authors: Achyuta Rajaram, Sarah Schwettmann, Jacob Andreas, Arthur Conmy
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Decoding Dark Matter: Specialized Sparse Autoencoders for Interpreting Rare Concepts in Foundation Models"
+            url: https://arxiv.org/abs/2411.00743
+            authors: Aashiq Muhamed, Mona Diab, Virginia Smith
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: Enhancing Neural Network Interpretability with Feature-Aligned Sparse Autoencoders
+            url: https://arxiv.org/abs/2411.01220
+            authors: Luke Marks, Alasdair Paren, David Krueger, Fazl Barez
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: BatchTopK Sparse Autoencoders
+            url: https://arxiv.org/abs/2412.06410
+            authors: Bart Bussmann, Patrick Leask, Neel Nanda
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: Understanding sparse autoencoder scaling in the presence of feature manifolds
+            url: https://arxiv.org/abs/2509.02565
+            authors: Eric J. Michaud, Liv Gorton, Tom McGrath
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Internal states before wait modulate reasoning patterns
+            url: https://arxiv.org/abs/2510.04128
+            authors: Dmitrii Troitskii, Koyena Pal, Chris Wendler, Callum Stuart McDougall, Neel Nanda
+            year: 2025
+            venue: arXiv (EMNLP Findings 2025)
+            kind: paper_preprint
+          - title: "Position: Mechanistic Interpretability Should Prioritize Feature Consistency in SAEs"
+            url: https://arxiv.org/abs/2505.20254
+            authors: >-
+              Xiangchen Song, Aashiq Muhamed, Yujia Zheng, Lingjing Kong, Zeyu Tang, Mona T. Diab, Virginia Smith, Kun
+              Zhang
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: How Visual Representations Map to Language Feature Space in Multimodal LLMs
+            url: https://arxiv.org/abs/2506.11976
+            authors: Constantin Venhoff, Ashkan Khakzar, Sonia Joseph, Philip Torr, Neel Nanda
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Prisma: An Open Source Toolkit for Mechanistic Interpretability in Vision and Video"
+            url: https://arxiv.org/abs/2504.19475
+            authors: >-
+              Sonia Joseph, Praneet Suresh, Lorenz Hufe, Edward Stevinson, Robert Graham, Yash Vadi, Danilo Bzdok,
+              Sebastian Lapuschkin, Lee Sharkey, Blake Aaron Richards
+            year: 2025
+            venue: arXiv / CVPR Mechanistic Interpretability for Vision Workshop
+            kind: paper_preprint
+          - title: Interpreting Large Text-to-Image Diffusion Models with Dictionary Learning
+            url: https://arxiv.org/abs/2505.24360
+            authors: Stepan Shabalin, Ayush Panda, Dmitrii Kharlapenko, Abdur Raheem Ali, Yixiong Hao, Arthur Conmy
+            year: 2025
+            venue: CVPR 2025 - Mechanistic Interpretability for Vision Workshop
+            kind: paper_preprint
+          - title: "CRISP: Persistent Concept Unlearning via Sparse Autoencoders"
+            url: https://arxiv.org/abs/2508.13650
+            authors: Tomer Ashuach, Dana Arad, Aaron Mueller, Martin Tutek, Yonatan Belinkov
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "SAEs Can Improve Unlearning: Dynamic Sparse Autoencoder Guardrails for Precision Unlearning in LLMs"
+            url: https://arxiv.org/abs/2504.08192
+            authors: Aashiq Muhamed, Jacopo Bonato, Mona Diab, Virginia Smith
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Scaling Sparse Feature Circuit Finding to Gemma 9B
+            url: https://lesswrong.com/posts/PkeB4TLxgaNnSmddg/scaling-sparse-feature-circuit-finding-to-gemma-9b
+            authors: Diego Caples, Jatin Nainani, CallumMcDougall, rrenaud
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: Topological Data Analysis and Mechanistic Interpretability
+            url: https://lesswrong.com/posts/6oF6pRr2FgjTmiHus/topological-data-analysis-and-mechanistic-interpretability
+            authors: Gunnar Carlsson
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+      - id: interp_causal_abstractions
+        name: Causal Abstractions
+        summary: >-
+          Verify that a neural network implements a specific high-level causal model (like a logical algorithm) by
+          finding a mapping between high-level variables and low-level neural representations.
+        theoryOfChange: >-
+          By establishing a precise, causal mapping between a black-box neural network and a human-interpretable
+          algorithm, we can mathematically guarantee that the model is using safe reasoning processes and predict its
+          behavior on unseen inputs, rather than relying on behavioral testing alone.
+        seeAlso: a:interp_concept_based, a:interp_fundamental
+        orthodoxProblems:
+          - "4"
+        targetCase: worst-case
+        broadApproaches:
+          - cognitive
+        someNames:
+          - atticus-geiger
+          - christopher-potts
+          - thomas-icard
+          - theodora-mara-pslar
+          - sara-magliacane
+          - jiuding-sun
+          - jing-huang
+        estimatedFTEs: 10-30
+        critiques:
+          - >-
+            [The Misguided Quest for Mechanistic AI
+            Interpretability](https://www.google.com/search?q=https://open.substack.com/pub/aifrontiersmedia/p/the-misguided-quest-for-mechanistic),
+            [Interpretability Will Not Reliably Find Deceptive
+            AI](https://www.lesswrong.com/posts/PwnadG4BFjaER3MGf/interpretability-will-not-reliably-find-deceptive-ai).
+        papers:
+          - title: Combining Causal Models for More Accurate Abstractions of Neural Networks
+            url: https://arxiv.org/abs/2503.11429
+            authors: Theodora-Mara Pîslar, Sara Magliacane, Atticus Geiger
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: How Causal Abstraction Underpins Computational Explanation
+            url: https://arxiv.org/abs/2508.11214
+            authors: Atticus Geiger, Jacqueline Harding, Thomas Icard
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "HyperDAS: Towards Automating Mechanistic Interpretability with Hypernetworks"
+            url: https://arxiv.org/abs/2503.10894
+            authors: >-
+              Jiuding Sun, Jing Huang, Sidharth Baskaran, Karel D'Oosterlinck, Christopher Potts, Michael Sklar, Atticus
+              Geiger
+            year: 2025
+            venue: ICLR 2025
+            kind: paper_preprint
+      - id: data_attribution
+        name: Data attribution
+        summary: >-
+          Quantifies the influence of individual training data points on a model's specific behavior or output, allowing
+          researchers to trace model properties (like misalignment, bias, or factual errors) back to their source in the
+          training set.
+        theoryOfChange: >-
+          By attributing harmful, biased, or unaligned behaviors to specific training examples, researchers can audit
+          proprietary models, debug training data, enable effective data deletion/unlearning
+        seeAlso: a:alignment_data_quality
+        orthodoxProblems:
+          - "4"
+          - "1"
+        targetCase: average-case
+        broadApproaches:
+          - behavioral
+        someNames:
+          - philipp-alexander-kreer
+          - wilson-wu
+          - jin-hwa-lee
+          - matthew-smith
+          - abhilasha-ravichander
+          - andrew-wang
+          - jiacheng-liu
+          - jiaqi-ma
+          - junwei-deng
+          - yijun-pan
+        estimatedFTEs: 30-60
+        papers:
+          - title: Bayesian Influence Functions for Hessian-Free Data Attribution
+            url: https://arxiv.org/abs/2509.26544
+            authors: Philipp Alexander Kreer, Wilson Wu, Maxwell Adam, Zach Furman, Jesse Hoogland
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Influence Dynamics and Stagewise Data Attribution
+            url: https://arxiv.org/abs/2510.12071
+            authors: Jin Hwa Lee, Matthew Smith, Maxwell Adam, Jesse Hoogland
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: You Are What You Eat -- AI Alignment Requires Understanding How Data Shapes Structure and Generalisation
+            url: https://arxiv.org/abs/2502.05475
+            authors: >-
+              Simon Pepin Lehalleur, Jesse Hoogland, Matthew Farrugia-Roberts, Susan Wei, Alexander Gietelink Oldenziel,
+              George Wang, Liam Carroll, Daniel Murfet
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Information-Guided Identification of Training Data Imprint in (Proprietary) Large Language Models
+            url: https://arxiv.org/abs/2503.12072
+            authors: >-
+              Abhilasha Ravichander, Jillian Fisher, Taylor Sorensen, Ximing Lu, Yuchen Lin, Maria Antoniak, Niloofar
+              Mireshghallah, Chandra Bhagavatula, Yejin Choi
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: What is Your Data Worth to GPT? LLM-Scale Data Valuation with Influence Functions
+            url: https://arxiv.org/abs/2405.13954
+            authors: >-
+              Sang Keun Choe, Hwijeen Ahn, Juhan Bae, Kewen Zhao, Minsoo Kang, Youngseog Chung, Adithya Pratapa, Willie
+              Neiswanger, Emma Strubell, Teruko Mitamura, Jeff Schneider, Eduard Hovy, Roger Grosse, Eric Xing
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Distributional Training Data Attribution: What do Influence Functions Sample?"
+            url: https://arxiv.org/abs/2506.12965
+            authors: Bruno Mlodozeniec, Isaac Reid, Sam Power, David Krueger, Murat Erdogdu, Richard E. Turner, Roger Grosse
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Better Training Data Attribution via Better Inverse Hessian-Vector Products
+            url: https://arxiv.org/abs/2507.14740
+            authors: Andrew Wang, Elisa Nguyen, Runshi Yang, Juhan Bae, Sheila A. McIlraith, Roger Grosse
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "OLMoTrace: Tracing Language Model Outputs Back to Trillions of Training Tokens"
+            url: https://arxiv.org/abs/2504.07096
+            authors: >-
+              Jiacheng Liu, Taylor Blanton, Yanai Elazar, Sewon Min, YenSung Chen, Arnavi Chheda-Kothary, Huy Tran,
+              Byron Bischoff, Eric Marsh, Michael Schmitz, Cassidy Trier, Aaron Sarnat, Jenna James, Jon Borchardt,
+              Bailey Kuehl, Evie Cheng, Karen Farley, Sruthi Sreeram, Taira Anderson, David Albright, Carissa Schoenick,
+              Luca Soldaini, Dirk Groeneveld, Rock Yuren Pang, Pang Wei Koh, Noah A. Smith, Sophie Lebrecht, Yejin Choi,
+              Hannaneh Hajishirzi, Ali Farhadi, Jesse Dodge
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Detecting and Filtering Unsafe Training Data via Data Attribution with Denoised Representation
+            url: https://arxiv.org/abs/2502.11411
+            authors: Yijun Pan, Taiwei Shi, Jieyu Zhao, Jiaqi W. Ma
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "DATE-LM: Benchmarking Data Attribution Evaluation for Large Language Models"
+            url: https://arxiv.org/abs/2507.09424
+            authors: >-
+              Cathy Jiao, Yijun Pan, Emily Xiao, Daisy Sheng, Niket Jain, Hanzhang Zhao, Ishita Dasgupta, Jiaqi W. Ma,
+              Chenyan Xiong
+            year: 2025
+            venue: NeurIPS 2025 Datasets and Benchmarks Track
+            kind: paper_preprint
+          - title: Revisiting Data Attribution for Influence Functions
+            url: https://arxiv.org/abs/2508.07297
+            authors: Hongbo Zhu, Angelo Cangelosi
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "A Snapshot of Influence: A Local Data Attribution Framework for Online Reinforcement Learning"
+            url: https://openreview.net/forum?id=sYK4yPDuT1
+            authors: Yuzheng Hu, Fan Wu, Haotian Ye, David Forsyth, James Zou, Nan Jiang, Jiaqi W. Ma, Han Zhao
+            year: 2025
+            venue: NeurIPS 2025
+            kind: paper_published
+      - id: interp_other
+        name: Other interpretability
+        summary: Interpretability that does not fall well into other categories.
+        theoryOfChange: >-
+          Explore alternative conceptual frameworks (e.g., agentic, propositional) and physics-inspired methods (e.g.,
+          renormalization). Or be "pragmatic".
+        seeAlso: a:interp_fundamental, a:interp_concept_based
+        orthodoxProblems:
+          - "4"
+        someNames:
+          - lee-sharkey
+          - dario-amodei
+          - david-chalmers
+          - been-kim
+          - neel-nanda
+          - david-d-baek
+          - lauren-greenspan
+          - dmitry-vaintrob
+          - sam-marks
+          - jacob-pfau
+        estimatedFTEs: 30-60
+        critiques:
+          - >-
+            [The Misguided Quest for Mechanistic AI
+            Interpretability](https://aifrontiersmedia.substack.com/p/the-misguided-quest-for-mechanistic),
+            [Interpretability Will Not Reliably Find Deceptive
+            AI](https://www.lesswrong.com/posts/PwnadG4BFjaER3MGf/interpretability-will-not-reliably-find-deceptive-ai).
+        papers:
+          - title: "Agentic Interpretability: A Strategy Against Gradual Disempowerment"
+            url: https://www.alignmentforum.org/posts/s9z4mgjtWTPpDLxFy/agentic-interpretability-a-strategy-against-gradual
+            authors: Been Kim, John Hewitt, Neel Nanda, Noah Fiedel, Oyvind Tafjord
+            year: 2025
+            venue: AI Alignment Forum
+            kind: lesswrong
+          - title: Open Problems in Mechanistic Interpretability
+            url: https://arxiv.org/abs/2501.16496
+            authors: >-
+              Lee Sharkey, Bilal Chughtai, Joshua Batson, Jack Lindsey, Jeff Wu, Lucius Bushnaq, Nicholas
+              Goldowsky-Dill, Stefan Heimersheim, Alejandro Ortega, Joseph Bloom, Stella Biderman, Adria Garriga-Alonso,
+              Arthur Conmy, Neel Nanda, Jessica Rumbelow, Martin Wattenberg, Nandi Schoots, Joseph Miller, Eric J.
+              Michaud, Stephen Casper, Max Tegmark, William Saunders, David Bau, Eric Todd, Atticus Geiger, Mor Geva,
+              Jesse Hoogland, Daniel Murfet, Tom McGrath
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: The Urgency of Interpretability
+            url: https://www.darioamodei.com/post/the-urgency-of-interpretability
+            authors: Dario Amodei
+            year: 2025
+            venue: darioamodei.com
+            kind: blog_post
+          - title: Propositional Interpretability in Artificial Intelligence
+            url: https://arxiv.org/abs/2501.15740
+            authors: David J. Chalmers
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Explainable and Interpretable Multimodal Large Language Models: A Comprehensive Survey"
+            url: https://arxiv.org/abs/2412.02104
+            authors: >-
+              Yunkai Dang, Kaichen Huang, Jiahao Huo, Yibo Yan, Sirui Huang, Dongrui Liu, Mengxi Gao, Jie Zhang, Chen
+              Qian, Kun Wang, Yong Liu, Jing Shao, Hui Xiong, Xuming Hu
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: Harmonic Loss Trains Interpretable AI Models
+            url: https://arxiv.org/abs/2502.01628
+            authors: David D. Baek, Ziming Liu, Riya Tyagi, Max Tegmark
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Through a Steerable Lens: Magnifying Neural Network Interpretability via Phase-Based Extrapolation"
+            url: https://arxiv.org/abs/2506.02300
+            authors: Farzaneh Mahdisoltani, Saeed Mahdisoltani, Roger B. Grosse, David J. Fleet
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Transformers Don't Need LayerNorm at Inference Time: Implications for Interpretability"
+            url: https://lesswrong.com/posts/KbFuuaBKRP7FcAADL/transformers-don-t-need-layernorm-at-inference-time
+            authors: submarat, Joachim Schaeffer, Luca Baroni, galvsk, StefanHex
+            year: 2025
+            venue: LessWrong / arXiv
+            kind: lesswrong
+          - title: Against blanket arguments against interpretability
+            url: https://lesswrong.com/posts/u3ZysuXEjkyHhefrk/against-blanket-arguments-against-interpretability
+            authors: Dmitry Vaintrob
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: "Opportunity Space: Renormalization for AI Safety"
+            url: https://lesswrong.com/posts/wkGmouy7JnTNtWAbc/opportunity-space-renormalization-for-ai-safety
+            authors: Lauren Greenspan, Dmitry Vaintrob, Lucas Teixeira
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: "Prospects for Alignment Automation: Interpretability Case Study"
+            url: https://lesswrong.com/posts/y5cYisQ2QHiSbQbhk/prospects-for-alignment-automation-interpretability-case
+            authors: Jacob Pfau, Geoffrey Irving
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: Downstream applications as validation of interpretability progress
+            url: https://lesswrong.com/posts/wGRnzCFcowRCrpX4Y/downstream-applications-as-validation-of-interpretability
+            authors: Sam Marks
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: Principles for Picking Practical Interpretability Projects
+            url: https://lesswrong.com/posts/DqaoPNqhQhwBFqWue/principles-for-picking-practical-interpretability-projects
+            authors: Sam Marks
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: "Renormalization Redux: QFT Techniques for AI Interpretability"
+            url: https://lesswrong.com/posts/sjr66DBEgyogAbfdf/renormalization-redux-qft-techniques-for-ai-interpretability
+            authors: Lauren Greenspan, Dmitry Vaintrob
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: >-
+              The Strange Science of Interpretability: Recent Papers and a Reading List for the Philosophy of
+              Interpretability
+            url: https://lesswrong.com/posts/qRnupMmFG7dxQTTYh/the-strange-science-of-interpretability-recent-papers-and-a
+            authors: Kola Ayonrinde, Louis Jaburi
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: "Call for Collaboration: Renormalization for AI safety"
+            url: https://lesswrong.com/posts/MDWGcNHkZ3NPEzcnp/call-for-collaboration-renormalization-for-ai-safety
+            authors: Lauren Greenspan
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: Where Did It Go Wrong? Attributing Undesirable LLM Behaviors via Representation Gradient Tracing
+            url: https://arxiv.org/abs/2510.02334
+            authors: Zhe Li, Wei Zhao, Yige Li, Jun Sun
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Language Models May Verbatim Complete Text They Were Not Explicitly Trained On
+            url: https://arxiv.org/abs/2503.17514
+            authors: >-
+              Ken Ziyu Liu, Christopher A. Choquette-Choo, Matthew Jagielski, Peter Kairouz, Sanmi Koyejo, Percy Liang,
+              Nicolas Papernot
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Extracting memorized pieces of (copyrighted) books from open-weight language models
+            url: https://arxiv.org/abs/2505.12546
+            authors: >-
+              A. Feder Cooper, Aaron Gokaslan, Ahmed Ahmed, Amy B. Cyphert, Christopher De Sa, Mark A. Lemley, Daniel E.
+              Ho, Percy Liang
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: A Pragmatic Vision for Interpretability
+            url: https://www.alignmentforum.org/posts/StENzDcD3kpfGJssR/a-pragmatic-vision-for-interpretability
+            authors: >-
+              Neel Nanda, Josh Engels, Arthur Conmy, Senthooran Rajamanoharan, bilalchughtai, CallumMcDougall, János
+              Kramár, lewis smith
+            year: 2025
+            venue: AI Alignment Forum
+            kind: lesswrong
+          - title: "On the creation of narrow AI: hierarchy and nonlocality of neural network skills"
+            url: https://arxiv.org/abs/2505.15811
+            authors: Eric J. Michaud, Asher Parker-Sartori, Max Tegmark
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+  - id: safety_by_construction
+    name: Safety by construction
+    description: Approaches which minimise the use of singleton deep learning models.
+    agendas:
+      - id: formal_verification
+        name: Guaranteed Safe AI
+        summary: >-
+          Formally model the behavior of cyber-physical systems, construct formally verified shells and interfaces which
+          pose precise constraints on what actions can occur, and require AIs to provide safety guarantees for their
+          recommended actions (correctness and uniqueness)
+        theoryOfChange: >-
+          Make a formal verification system that can act as an intermediary between human users and a potentially
+          dangerous system, only letting provably safe actions through. (Notable for not requiring that we solve ELK;
+          does require that we solve ontology though)
+        seeAlso: >-
+          [Synthesizing Standalone
+          World-Models](https://www.alignmentforum.org/posts/LngR93YwiEpJ3kiWh/research-agenda-synthesizing-standalone-world-models),
+          a:scientist_ai, Safeguarded AI, Open Agency Architecture, SLES, program synthesis
+        orthodoxProblems:
+          - "1"
+          - "4"
+        targetCase: worst-case
+        broadApproaches:
+          - cognitive
         someNames:
           - aria
           - lawzero
           - atlas-computing
           - flf
           - max-tegmark
+          - beneficial-ai-foundationhttpswwwbeneficialaifoundationorg
           - steve-omohundro
-          - david-dalrymple
+          - david-davidad-dalrymple
           - joar-skalse
           - stuart-russell
           - ohad-kammar
           - alessandro-abate
           - fabio-zanassi
-        estimatedFTEs: "*(SR2024: 10-50)*"
-        fundedBy:
-          - manifund
-          - uk-aisi
-          - open-philanthropy
-          - survival-flourishing-fund
-          - mila-cifar
-        broadApproaches:
-          - cognitive
-        resources:
-          - title: GSAI Summit
-            url: https://www.gsais.org/
-          - title: "Towards Guaranteed Safe AI: A Framework for Ensuring Robust and Reliable AI Systems"
-            url: https://arxiv.org/abs/2405.06624
-      - id: tegmark
-        name: Tegmark
-        keywords:
-          - formal-verification
-          - world-models
-          - safety-cases
-          - abstractions
+        estimatedFTEs: 10-100
+        critiques:
+          - >-
+            Zvi, Gleave, Dickson,
+            [Greenblatt](https://www.lesswrong.com/posts/jRf4WENQnhssCb6mJ/davidad-s-bold-plan-for-alignment-an-in-depth-explanation?commentId=MJCvHk5ARMnWDjQDg)
         papers:
-          - title: https://arxiv.org/abs/2505.15811
-            url: https://arxiv.org/abs/2505.15811
-        summary: ""
-        theoryOfChange: ""
-        targetCase: ""
-        estimatedFTEs: ""
-        resources:
-          - title: Tegmark Group
-            url: https://tegmark.org/
-          - title: Future of Life Institute
-            url: https://futureoflife.org/
-      - id: scientist-ai
+          - title: "SafePlanBench: evaluating a Guaranteed Safe AI Approach for LLM-based Agents"
+            url: https://manifund.org/projects/safeplanbench-evaluating-a-guaranteed-safe-ai-approach-for-llm-based-agents
+            authors: Agustín Martinez Suñé, Tan Zhi Xuan
+            venue: Manifund
+            kind: agenda_manifesto
+          - title: Report on NSF Workshop on Science of Safe AI
+            url: https://arxiv.org/abs/2506.22492
+            authors: Rajeev Alur, Greg Durrett, Hadas Kress-Gazit, Corina Păsăreanu, René Vidal
+            year: 2025
+            venue: arXiv
+            kind: agenda_manifesto
+          - title: "A benchmark for vericoding: formally verified program synthesis"
+            url: https://arxiv.org/abs/2509.22908
+            authors: >-
+              Sergiu Bursuc, Theodore Ehrenborg, Shaowei Lin, Lacramioara Astefanoaei, Ionel Emilian Chiosa, Jure
+              Kukovec, Alok Singh, Oliver Butterley, Adem Bizid, Quinn Dougherty, Miranda Zhao, Max Tan, Max Tegmark
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Beliefs about formal methods and AI safety
+            url: https://lesswrong.com/posts/CCT7Qc8rSeRs7r5GL/beliefs-about-formal-methods-and-ai-safety
+            authors: Quinn Dougherty
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: AI-Assisted Formal Verification Toolchain
+            url: https://atlascomputing.org/ai-assisted-fv-toolchain.pdf
+            kind: error_detected
+      - id: scientist_ai
         name: Scientist AI
-        keywords:
-          - world-models
-          - agentic-systems
-          - corrigibility
-        papers:
-          - title: "Superintelligent Agents Pose Catastrophic Risks: Can Scientist AI Offer a Safer Path?"
-            url: https://arxiv.org/abs/2502.15657
-          - title: "The More You Automate, the Less You See: Hidden Pitfalls of AI Scientist Systems"
-            url: https://arxiv.org/abs/2509.08713
-        summary: Develop powerful, non-agentic, uncertainty-aware world-modeling systems that substantially accelerate scientific progress while avoiding the risks of building AIs that act as ‘agents’
-        theoryOfChange: "Developing non-agentic ‘Scientist AI’ allows us to: (i) reap the benefits of AI progress while (ii) avoiding the inherent risks of agentic systems. These systems can also (iii) provide a useful guardrail to protect us from unsafe agentic AIs by double-checking actions they propose, and (iv) help us more safely build agentic superintelligent systems."
-        seeAlso: "[JEPA](https://arxiv.org/abs/2511.08544)"
+        summary: >-
+          Develop powerful, non-agentic, uncertainty-aware world-modeling systems that substantially accelerate
+          scientific progress while avoiding the risks of building AIs that act as 'agents'
+        theoryOfChange: >-
+          Developing non-agentic 'Scientist AI' allows us to: (i) reap the benefits of AI progress while (ii) avoiding
+          the inherent risks of agentic systems. These systems can also (iii) provide a useful guardrail to protect us
+          from unsafe agentic AIs by double-checking actions they propose, and (iv) help us more safely build agentic
+          superintelligent systems.
+        seeAlso: "[JEPA](https://arxiv.org/abs/2511.08544), [oracles](https://www.lesswrong.com/w/oracle-ai)"
         orthodoxProblems:
-          - "3"
           - "4"
           - "5"
         targetCase: pessimistic
-        someNames:
-          - yoshua-bengio
-        estimatedFTEs: ""
-        critiques:
-          - "[Raymond Douglas’ comment](https://www.lesswrong.com/posts/p5gBcoQeBsvsMShvT/superintelligent-agents-pose-catastrophic-risks-can?commentId=tJXqhg3XZsqnyaZs2)"
-        fundedBy:
-          - aria
-          - future-of-life-institute
-          - jaan-tallinn
-          - schmidt-sciences
         broadApproaches:
           - cognitive
-      - id: conjecture-cognitive-software
-        name: "Conjecture: Cognitive Software"
-        lesswrongTags:
-          - conjecture-org
-        keywords:
-          - corrigibility
-          - personas
-          - world-models
-          - agentic-systems
-        papers: []
-        summary: ""
-        theoryOfChange: ""
-        seeAlso: "[uploadism](https://www.alignmentforum.org/posts/AzFxTMFfkTt4mhMKt/alignment-as-uploading-with-more-steps)"
-        targetCase: ""
-        estimatedFTEs: ""
-        resources:
-          - title: Conjecture
-            url: https://www.conjecture.dev/
-          - title: Cognitive Emulation
-            url: https://www.conjecture.dev/cognitive-emulation
-      - id: brainlike-agi-safety
-        name: Brainlike-AGI Safety
-        keywords:
-          - corrigibility
-          - rlhf
-          - world-models
+        someNames:
+          - yoshua-bengio
+        estimatedFTEs: 1-10
+        critiques:
+          - >-
+            Hard to find, but see [Raymond Douglas'
+            comment](https://www.lesswrong.com/posts/p5gBcoQeBsvsMShvT/superintelligent-agents-pose-catastrophic-risks-can?commentId=tJXqhg3XZsqnyaZs2),
+            [Karnofsky-Soares
+            discussion](https://www.lesswrong.com/posts/iy2o4nQj9DnQD7Yhj/discussion-with-nate-soares-on-a-key-alignment-difficulty).
+            Perhaps also
+            [Predict-O-Matic](https://www.lesswrong.com/posts/SwcyMEgLyd4C3Dern/the-parable-of-predict-o-matic).
         papers:
-          - title: https://www.lesswrong.com/posts/yew6zFWAKG4AGs3Wk/foom-and-doom-1-brain-in-a-box-in-a-basement
+          - title: "Superintelligent Agents Pose Catastrophic Risks: Can Scientist AI Offer a Safer Path?"
+            url: https://arxiv.org/abs/2502.15657
+            authors: >-
+              Yoshua Bengio, Michael Cohen, Damiano Fornasiere, Joumana Ghosn, Pietro Greiner, Matt MacDermott, Sören
+              Mindermann, Adam Oberman, Jesse Richardson, Oliver Richardson, Marc-Antoine Rondeau, Pierre-Luc
+              St-Charles, David Williams-King
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "The More You Automate, the Less You See: Hidden Pitfalls of AI Scientist Systems"
+            url: https://arxiv.org/abs/2509.08713
+            authors: Ziming Luo, Atoosa Kasirzadeh, Nihar B. Shah
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+      - id: brainlike_agi
+        name: Brainlike-AGI Safety
+        summary: >-
+          Social and moral instincts are (partly) implemented in particular hardwired brain circuitry; let's figure out
+          what those circuits are and how they work; this will involve symbol grounding. "a yet-to-be-invented variation
+          on actor-critic model-based reinforcement learning"
+        theoryOfChange: >-
+          Fairly direct alignment via changing training to reflect actual human reward. Get actual data about (reward,
+          training data) → (human values) to help with theorising this map in AIs; "understand human social instincts,
+          and then maybe adapt some aspects of those for AGIs, presumably in conjunction with other non-biological
+          ingredients".
+        targetCase: worst-case
+        broadApproaches:
+          - cognitive
+        someNames:
+          - stephen-byrnes
+        estimatedFTEs: 1-5
+        critiques:
+          - >-
+            [Tsvi
+            BT](https://www.lesswrong.com/posts/unCG3rhyMJpGJpoLd/koan-divining-alien-datastructures-from-ram-activations#BtHCubjKWDFafkmYH)
+        papers:
+          - title: "Foom and Doom 1: Brain in a Box in a Basement"
             url: https://www.lesswrong.com/posts/yew6zFWAKG4AGs3Wk/foom-and-doom-1-brain-in-a-box-in-a-basement
-          - title: https://www.lesswrong.com/posts/bnnKGSCHJghAvqPjS/foom-and-doom-2-technical-alignment-is-hard
+            venue: LessWrong
+            kind: blocked
+          - title: "Foom and Doom 2: Technical Alignment is Hard"
             url: https://www.lesswrong.com/posts/bnnKGSCHJghAvqPjS/foom-and-doom-2-technical-alignment-is-hard
-          - title: https://www.lesswrong.com/posts/grgb2ipxQf2wzNDEG/perils-of-under-vs-over-sculpting-agi-desires
+            venue: LessWrong
+            kind: error_detected
+          - title: Perils of Under vs Over-sculpting AGI Desires
             url: https://www.lesswrong.com/posts/grgb2ipxQf2wzNDEG/perils-of-under-vs-over-sculpting-agi-desires
+            venue: LessWrong
+            kind: error_detected
           - title: Reward button alignment
             url: https://lesswrong.com/posts/JrTk2pbqp7BFwPAKw/reward-button-alignment
             authors: Steven Byrnes
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
           - title: "System 2 Alignment: Deliberation, Review, and Thought Management"
             url: https://lesswrong.com/posts/cus5CGmLrjBRgcPSF/system-2-alignment-deliberation-review-and-thought
             authors: Seth Herd
-          - title: https://elicit.com/blog/system-2-learning
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: "Against RL: The Case for System 2 Learning"
             url: https://elicit.com/blog/system-2-learning
-        summary: Social and moral instincts are (partly) implemented in particular hardwired brain circuitry; let's figure out what those circuits are and how they work; this will involve symbol grounding. “a yet-to-be-invented variation on actor-critic model-based reinforcement learning”
-        theoryOfChange: Fairly direct alignment via changing training to reflect actual human reward. Get actual data about (reward, training data) → (human values) to help with theorising this map in AIs; "understand human social instincts, and then maybe adapt some aspects of those for AGIs, presumably in conjunction with other non-biological ingredients".
-        targetCase: worst-case
-        someNames:
-          - stephen-byrnes
-        estimatedFTEs: "1"
-        fundedBy:
-          - astera-institute
-        broadApproaches:
-          - cognitive
-  - id: make-ai-solve-it
+            authors: Andreas Stuhlmüller
+            year: 2025
+            venue: Elicit Blog
+            kind: blog_post
+  - id: ai_solve_alignment
     name: Make AI solve it
-    description: Use AI systems to help solve alignment
     agendas:
-      - id: weak-to-strong-generalization
+      - id: weak_to_strong
         name: Weak-to-strong generalization
-        keywords:
-          - scalable-oversight
-          - capability-elicitation
-          - rlhf
-        papers:
-          - title: Debate Helps Weak-to-Strong Generalization
-            url: https://arxiv.org/abs/2501.13124
-          - title: Understanding the Capabilities and Limitations of Weak-to-Strong Generalization
-            url: https://openreview.net/forum?id=RwYdLgj1S6
-          - title: Great Models Think Alike and this Undermines AI Oversight
-            url: https://arxiv.org/abs/2502.04313
-          - title: Scaling Laws For Scalable Oversight
-            url: https://arxiv.org/abs/2504.18530
         summary: Use weaker models to supervise and provide a feedback signal to stronger models.
-        theoryOfChange: Find techniques that do better than RLHF at supervising superior models → track whether these techniques fail as capabilities increase further → keep the stronger systems aligned by amplifying weak oversight and quantifying where it breaks.
-        seeAlso: Supervising AIs improving AIs.
-        orthodoxProblems:
-          - "8"
-        targetCase: optimistic
+        theoryOfChange: >-
+          Find techniques that do better than RLHF at supervising superior models → track whether these techniques fail
+          as capabilities increase further → keep the stronger systems aligned by amplifying weak oversight and
+          quantifying where it breaks.
+        seeAlso: a:supervising_improvement
+        targetCase: average-case
+        broadApproaches:
+          - engineering
         someNames:
           - joshua-engels
           - nora-belrose
-          - "* David D. Baek."
-        estimatedFTEs: "*(SR2024: 10-50)*"
+          - david-d-baek
+        estimatedFTEs: 2-20
         critiques:
-          - "[Can we safely automate alignment research?](https://joecarlsmith.substack.com/p/can-we-safely-automate-alignment)"
-          - "[Super(ficial)-alignment: Strong Models May Deceive Weak Models in Weak-to-Strong Generalization](https://arxiv.org/abs/2406.11431)"
-        fundedBy:
-          - eleutherai
-        broadApproaches:
-          - engineering
-        resources:
-          - title: OpenAI Research
-            url: https://openai.com/index/weak-to-strong-generalization/
-          - title: "Weak-to-Strong Generalization: Eliciting Strong Capabilities With Weak Supervision"
-            url: https://arxiv.org/abs/2312.09390
-      - id: supervising-ais-improving-ais
-        name: Supervising AIs improving AIs
-        lesswrongTags:
-          - ai-assisted-alignment
-          - scalable-oversight
-        keywords:
-          - scalable-oversight
-          - agentic-systems
-          - monitoring
+          - >-
+            [Can we safely automate alignment
+            research?](https://joecarlsmith.substack.com/p/can-we-safely-automate-alignment), [Super(ficial)-alignment:
+            Strong Models May Deceive Weak Models in Weak-to-Strong Generalization](https://arxiv.org/abs/2406.11431)
         papers:
-          - title: https://saif.org/research/bare-minimum-mitigations-for-autonomous-ai-development
-            url: https://saif.org/research/bare-minimum-mitigations-for-autonomous-ai-development
+          - title: Debate Helps Weak-to-Strong Generalization
+            url: https://arxiv.org/abs/2501.13124
+            authors: Hao Lang, Fei Huang, Yongbin Li
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Understanding the Capabilities and Limitations of Weak-to-Strong Generalization
+            url: https://openreview.net/forum?id=RwYdLgj1S6
+            authors: Wei Yao, Wenkai Yang, Ziqiao Wang, Yankai Lin, Yong Liu
+            year: 2025
+            venue: ICLR 2025 Workshop SSI-FM
+            kind: paper_published
+          - title: Great Models Think Alike and this Undermines AI Oversight
+            url: https://arxiv.org/abs/2502.04313
+            authors: >-
+              Shashwat Goel, Joschka Struber, Ilze Amanda Auzina, Karuna K Chandra, Ponnurangam Kumaraguru, Douwe Kiela,
+              Ameya Prabhu, Matthias Bethge, Jonas Geiping
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Scaling Laws For Scalable Oversight
+            url: https://arxiv.org/abs/2504.18530
+            authors: Joshua Engels, David D. Baek, Subhash Kantamneni, Max Tegmark
+            year: 2025
+            venue: arXiv (NeurIPS 2025 Spotlight)
+            kind: paper_preprint
+      - id: supervising_improvement
+        name: Supervising AIs improving AIs
+        summary: >-
+          Build formal and empirical frameworks where AIs supervise other (stronger) AI systems via structured
+          interactions; construct monitoring tools which enable scalable tracking of behavioural drift, benchmarks for
+          self-modification, and robustness guarantees
+        theoryOfChange: >-
+          Early models train ~only on human data while later models also train on early model outputs, which leads to
+          early model problems cascading. Left unchecked this will likely cause problems, so supervision mechanisms are
+          needed to help ensure the AI self-improvement remains legible.
+        targetCase: pessimistic
+        broadApproaches:
+          - behavioral
+        someNames:
+          - roman-engeler
+          - akbir-khan
+          - ethan-perez
+        estimatedFTEs: 1-10
+        critiques:
+          - >-
+            [Automation collapse](https://www.lesswrong.com/posts/2Gy9tfjmKwkYbF9BY/automation-collapse), [Great Models
+            Think Alike and this Undermines AI Oversight](https://arxiv.org/abs/2502.04313)
+        papers:
+          - title: Bare Minimum Mitigations for Autonomous AI Development
+            url: https://saif.org/research/bare-minimum-mitigations-for-autonomous-ai-development/
+            authors: >-
+              Joshua Clymer, Isabella Duan, Chris Cundy, Yawen Duan, Fynn Heide, Chaochao Lu, Sören Mindermann, Conor
+              McGurk, Xudong Pan, Saad Siddiqui, Jingren Wang, Min Yang, Xianyuan Zhan
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
           - title: Maintaining Alignment during RSI as a Feedback Control Problem
             url: https://lesswrong.com/posts/PhgEKkB4cwYjwpGxb/maintaining-alignment-during-rsi-as-a-feedback-control
             authors: beren
-          - title: Scaling Laws for Scalable Oversight
-            url: https://www.google.com/url?q=https://arxiv.org/abs/2504.18530&sa=D&source=docs&ust=1764169943848285&usg=AOvVaw0y4hN8GA8F5MlxPrpbt_-c
-            authors: Subhash Kantamneni, Josh Engels, David Baek, Max Tegmark
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: Scaling Laws For Scalable Oversight
+            url: https://arxiv.org/abs/2504.18530
+            authors: Joshua Engels, David D. Baek, Subhash Kantamneni, Max Tegmark
+            year: 2025
+            venue: arXiv (NeurIPS 2025 Spotlight)
+            kind: paper_preprint
           - title: Neural Interactive Proofs
             url: https://arxiv.org/abs/2412.08897
             authors: Lewis Hammond, Sam Adam-Day
+            year: 2024
+            venue: arXiv (ICLR 2025)
+            kind: paper_preprint
           - title: Video and transcript of talk on automating alignment research
             url: https://lesswrong.com/posts/TQbptN7F4ijPnQRLy/video-and-transcript-of-talk-on-automating-alignment
             authors: Joe Carlsmith
-        summary: Build formal and empirical frameworks where AIs supervise other (stronger) AI systems via structured interactions; construct monitoring tools which enable scalable tracking of behavioural drift, benchmarks for self-modification, and robustness guarantees
-        theoryOfChange: Early models train \~only on human data while later models also train on early model outputs, which leads to early model problems cascading. Left unchecked this will likely cause problems, so supervision mechanisms are needed to help ensure the AI self-improvement remains legible.
-        orthodoxProblems:
-          - "7"
-          - "8"
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: Modeling Human Beliefs about AI Behavior for Scalable Oversight
+            url: https://arxiv.org/abs/2502.21262
+            authors: Leon Lang, Patrick Forré
+            year: 2025
+            venue: Transactions on Machine Learning Research
+            kind: paper_published
+          - title: Scalable Oversight for Superhuman AI via Recursive Self-Critiquing
+            url: https://arxiv.org/abs/2502.04675
+            authors: Xueru Wen, Jie Lou, Xinyu Lu, Junjie Yang, Yanjiang Liu, Yaojie Lu, Debing Zhang, Xing Yu
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Dodging systematic human errors in scalable oversight
+            url: >-
+              https://www.alignmentforum.org/posts/EgRJtwQurNzz8CEfJ/dodging-systematic-human-errors-in-scalable-oversight
+      - id: transluce
+        name: Transluce
+        summary: >-
+          Make open AI tools to explain AIs, including agents. E.g. feature descriptions for neuron activation patterns;
+          an interface for steering these features; behavior elicitation agent that searches for user-specified
+          behaviors from frontier models
+        theoryOfChange: Improve interp and evals in public and get invited to improve lab processes.
         targetCase: pessimistic
-        someNames:
-          - "*(SR2024: Roman Engeler"
-          - akbir-khan
-          - ethan-perez
-        estimatedFTEs: "*(SR2024: 1-10)*"
-        fundedBy:
-          - long-term-future-fund
         broadApproaches:
-          - behavioral
-      - id: deepmind-amplified-oversight
-        name: DeepMind Amplified Oversight
-        lesswrongTags:
-          - scalable-oversight
-        keywords:
-          - scalable-oversight
-          - iterated-amplification
-        papers: []
-        summary: ""
-        theoryOfChange: ""
-        targetCase: ""
-        estimatedFTEs: ""
+          - cognitive
+        someNames:
+          - jacob-steinhardt
+          - neil-chowdhury
+          - vincent-huang
+          - sarah-schwettmann
+          - robert-friel
+        estimatedFTEs: 15-30
+        papers:
+          - title: Automatically Jailbreaking Frontier Language Models with Investigator Agents
+            url: https://transluce.org/jailbreaking-frontier-models
+          - title: Investigating truthfulness in a pre-release o3 model
+            url: https://transluce.org/investigating-o3-truthfulness
+            authors: Neil Chowdhury, Daniel Johnson, Vincent Huang, Jacob Steinhardt, Sarah Schwettmann
+            year: 2025
+            venue: Transluce Blog
+            kind: blog_post
+          - title: Surfacing Pathological Behaviors in Language Models
+            url: https://transluce.org/pathological-behaviors
+          - title: Introducing Docent
+            url: https://transluce.org/introducing-docent
+            authors: Kevin Meng, Vincent Huang, Jacob Steinhardt, Sarah Schwettmann
+            year: 2025
+            venue: Transluce Blog
+            kind: blog_post
+          - title: Language Model Circuits Are Sparse in the Neuron Basis
+            url: https://transluce.org/neuron-circuits
+            authors: Aryaman Arora, Zhengxuan Wu, Jacob Steinhardt, Sarah Schwettmann
+            year: 2025
+            venue: Transluce AI
+            kind: paper_preprint
       - id: debate
         name: Debate
-        lesswrongTags:
-          - debate-ai-safety-technique-1
-        keywords:
-          - debate
-          - scalable-oversight
-          - safety-cases
-        papers:
-          - title: AI Debate Aids Assessment of Controversial Claims
-            url: https://arxiv.org/abs/2506.02175
-            authors: Salman Rahman, Sheriff Issaka, Ashima Suvarna et al.
-          - title: An alignment safety case sketch based on debate
-            url: https://arxiv.org/abs/2505.03989
-            authors: Marie Davidsen Buhl, Jacob Pfau, Benjamin Hilton et al.
         summary: Make highly capable agents do what humans want, even when it is difficult for humans to know what that is.
-        theoryOfChange: "\"Give humans help in supervising strong agents\" \\+ \"Align explanations with the true reasoning process of the agent\" \\+ \"Red team models to exhibit failure modes that don't occur in normal use\" are necessary but probably not sufficient for safe AGI."
+        theoryOfChange: >-
+          "Give humans help in supervising strong agents" + "Align explanations with the true reasoning process of the
+          agent" + "Red team models to exhibit failure modes that don't occur in normal use" are necessary but probably
+          not sufficient for safe AGI.
         orthodoxProblems:
           - "1"
-          - "7"
         targetCase: worst-case
         someNames:
           - rohin-shah
           - jonah-brown-cohen
           - georgios-piliouras
-        estimatedFTEs: "?"
-        fundedBy:
-          - google-deepmind
-        broadApproaches:
-          - engineering
-          - cognitive
-        resources:
-          - title: "AI Safety via Debate"
-            url: https://arxiv.org/abs/1805.00899
-          - title: Anthropic Debate Progress Update
-            url: https://www.alignmentforum.org/posts/QtqysYdJRenWFeWc4/anthropic-fall-2023-debate-progress-update
-      - id: task-decomposition
-        name: Task decomposition
-        lesswrongTags:
-          - scalable-oversight
-        keywords:
-          - scalable-oversight
-          - iterated-amplification
-          - agentic-systems
-        papers: []
-        summary: ""
-        theoryOfChange: ""
-        targetCase: ""
-        estimatedFTEs: ""
-        resources:
-          - title: Iterated Distillation and Amplification
-            url: https://ai-alignment.com/iterated-distillation-and-amplification-157debfd1616
-      - id: adversarial-oversight
-        name: Adversarial oversight
-        lesswrongTags:
-          - scalable-oversight
-          - adversarial-training
-        keywords:
-          - red-teaming
-          - scalable-oversight
-          - monitoring
+          - uk-aisi-benjamin-holton
+        critiques:
+          - >-
+            [The limits of AI safety via debate
+            (2022)](https://www.lesswrong.com/posts/kguLeJTt6LnGuYX4E/the-limits-of-ai-safety-via-debate)
         papers:
-          - title: https://www.semafor.com/article/11/05/2025/microsoft-superintelligence-team-promises-to-keep-humans-in-charge
-            url: https://www.semafor.com/article/11/05/2025/microsoft-superintelligence-team-promises-to-keep-humans-in-charge
-        summary: ""
-        theoryOfChange: ""
-        targetCase: ""
-        estimatedFTEs: ""
+          - title: AI Debate Aids Assessment of Controversial Claims
+            url: https://arxiv.org/abs/2506.02175
+            authors: >-
+              Salman Rahman, Sheriff Issaka, Ashima Suvarna, Genglin Liu, James Shiffer, Jaeyoung Lee, Md Rizwan Parvez,
+              Hamid Palangi, Shi Feng, Nanyun Peng, Yejin Choi, Julian Michael, Liwei Jiang, Saadia Gabriel
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: An alignment safety case sketch based on debate
+            url: https://arxiv.org/abs/2505.03989
+            authors: Marie Davidsen Buhl, Jacob Pfau, Benjamin Hilton, Geoffrey Irving
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "UK AISI Alignment Team: Debate Sequence"
+            url: https://www.lesswrong.com/s/NdovveRcyfxgMoujf
+            authors: Benjamin Hilton
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: "Prover-Estimator Debate: A New Scalable Oversight Protocol"
+            url: https://lesswrong.com/posts/8XHBaugB5S3r27MG9/prover-estimator-debate-a-new-scalable-oversight-protocol
+            authors: Jonah Brown-Cohen, Geoffrey Irving
+            year: 2025
+            venue: LessWrong / AI Alignment Forum
+            kind: lesswrong
+          - title: Ensemble Debates with Local Large Language Models for AI Alignment
+            url: https://arxiv.org/abs/2509.00091
+            authors: Ephraiem Sarabamoun
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+      - id: introspection_training
+        name: LLM introspection training
+        summary: >-
+          Train LLMs to the predict the outputs of high-quality whitebox explainability methods, in order to induce the
+          LLM to learn generalized self-explanation skills that use its own natural 'introspective' access
+        theoryOfChange: >-
+          Integrating self-explanation into an LLM's core skillset should lead to default scalability, since
+          self-explanation skill advancement will feed off general-intelligence advancement
+        seeAlso: a:transluce
+        orthodoxProblems:
+          - "4"
+        broadApproaches:
+          - cognitive
+        someNames:
+          - belinda-z-li
+          - zifan-carl-guo
+          - vincent-huang
+          - jacob-steinhardt
+          - jacob-andreas
+        estimatedFTEs: 2-20
+        papers:
+          - title: Training Language Models to Explain Their Own Computations
+            url: https://arxiv.org/abs/2511.08579
   - id: theory
     name: Theory
-    description: How to understand and control current and future models
+    description: >-
+      Develop a principled scientific understanding that will help us reliably understand and control current and future
+      AI systems.
     agendas:
-      - id: agent-foundations
+      - id: agent_foundations
         name: Agent foundations
-        lesswrongTags:
-          - agent-foundations
-        keywords:
-          - decision-theory
-          - corrigibility
-          - ontology
-          - abstractions
-          - mesa-optimization
-          - power-seeking
-        papers:
-          - title: There is No Reliable Estimate of P(doom)
-            url: https://static1.squarespace.com/static/678814b5570c5a7a78df555d/t/67d09e77f3364b72d1ee91d7/1741725303556/Günther+-+There+is+No+Reliable+P%28doom%29+-+Mario+Guenther.pdf
-            authors: Mario Gunther
-          - title: https://www.arxiv.org/pdf/2508.16245
-            url: https://www.arxiv.org/pdf/2508.16245
-          - title: https://uaiasi.com/blog-posts/
-            url: https://uaiasi.com/blog-posts/
-          - title: Off-switching not guaranteed
-            url: https://link.springer.com/article/10.1007/s11098-025-02296-x
-            authors: Sam Eisenstat
-          - title: https://openreview.net/pdf?id=Rf1CeGPA22
-            url: https://openreview.net/pdf?id=Rf1CeGPA22
-          - title: Formalizing Embeddedness Failures in Universal Artificial Intelligence
-            url: https://openreview.net/forum?id=tlkYPU3FlX
-            authors: Cole Wyeth, Marcus Hutter
-          - title: "Clarifying “wisdom”: Foundational topics for aligned AIs to prioritize before irreversible decisions"
-            url: https://www.lesswrong.com/posts/EyvJvYEFzDv5kGoiG/clarifying-wisdom-foundational-topics-for-aligned-ais-to
-            authors: Anthony DiGiovanni
-          - title: "Agent foundations: not really math, not really science"
-            url: https://www.lesswrong.com/posts/Dt4DuCCok3Xv5HEnG/agent-foundations-not-really-math-not-really-science
-            authors: Alex Altair
-          - title: Is alignment reducible to becoming more coherent?
-            url: https://lesswrong.com/posts/nuDJNyG5XLQjtvaeg/is-alignment-reducible-to-becoming-more-coherent
-            authors: Cole Wyeth
-          - title: What Is The Alignment Problem?
-            url: https://lesswrong.com/posts/dHNKtQ3vTBxTfTPxu/what-is-the-alignment-problem
-            authors: johnswentworth
-        summary: Develop philosophical clarity and mathematical formalization of building blocks that might be useful for plans to align strong superintelligence, such as agency, decision theory, abstractions, concepts, etcInvestigate what an ‘agent’ is, what it means for an agent to be aligned, and what are the deep structural constraints on ‘agents’ in our universe
-        theoryOfChange: Rigorously understand what agents are/what it means for them to be aligned in a substrate independent way → identify impossibility results and necessary conditions for aligned agentic systems → use this theoretical understanding to eventually design safe architectures that remain stable and safe under self-reflection
+        summary: >-
+          Develop philosophical clarity and mathematical formalizations of building blocks that might be useful for
+          plans to align strong superintelligence, such as agency, optimization strength, decision theory, abstractions,
+          concepts, etc.
+        theoryOfChange: >-
+          Rigorously understand optimization processed and agents, and what it means for them to be aligned in a
+          substrate independent way → identify impossibility results and necessary conditions for aligned optimizer
+          systems → use this theoretical understanding to eventually design safe architectures that remain stable and
+          safe under self-reflection
+        seeAlso: a:tiling_agents, a:theory_dovetail
         orthodoxProblems:
           - "1"
-          - "2"
           - "4"
         targetCase: worst-case
+        broadApproaches:
+          - cognitive
         someNames:
           - abram-demski
           - alex-altair
-        estimatedFTEs: ""
+          - sam-eisenstat
+          - thane-ruthenis
+        papers:
+          - title: Limit-Computable Grains of Truth for Arbitrary Computable Extensive-Form (Un)Known Games
+            url: https://www.arxiv.org/pdf/2508.16245
+            authors: Cole Wyeth, Marcus Hutter, Jan Leike, Jessica Taylor
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Blog Posts – Universal Algorithmic Intelligence
+            url: https://uaiasi.com/blog-posts/
+            authors: Cole Wyeth
+            year: 2025
+            venue: Universal Algorithmic Intelligence website
+            kind: blog_post
+          - title: Off-switching not guaranteed
+            url: https://link.springer.com/article/10.1007/s11098-025-02296-x
+            authors: Sven Neth
+            year: 2025
+            venue: Philosophical Studies
+            kind: paper_published
+          - title: Unable to extract - PDF content not accessible
+            url: https://openreview.net/pdf?id=Rf1CeGPA22
+            venue: OpenReview
+            kind: error_detected
+          - title: Formalizing Embeddedness Failures in Universal Artificial Intelligence
+            url: https://openreview.net/forum?id=tlkYPU3FlX
+            authors: Cole Wyeth, Marcus Hutter
+            year: 2025
+            venue: ODYSSEY 2025 Conference
+            kind: paper_preprint
+          - title: "Unable to access: 429 Too Many Requests"
+            url: https://www.lesswrong.com/posts/EyvJvYEFzDv5kGoiG/clarifying-wisdom-foundational-topics-for-aligned-ais-to
+            venue: LessWrong
+            kind: error_detected
+          - title: "Agent foundations: not really math, not really science"
+            url: https://www.lesswrong.com/posts/Dt4DuCCok3Xv5HEnG/agent-foundations-not-really-math-not-really-science
+            authors: Alex_Altair
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: Is alignment reducible to becoming more coherent?
+            url: https://lesswrong.com/posts/nuDJNyG5XLQjtvaeg/is-alignment-reducible-to-becoming-more-coherent
+            authors: Cole Wyeth
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: What Is The Alignment Problem?
+            url: https://lesswrong.com/posts/dHNKtQ3vTBxTfTPxu/what-is-the-alignment-problem
+            authors: johnswentworth
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+      - id: tiling_agents
+        name: Tiling agents
+        summary: >-
+          An aligned agentic system modifying itself into an unaligned system would be bad and we can research ways that
+          this could occur and infrastructure/approaches that prevent it from happening.
+        theoryOfChange: >-
+          Build enough theoretical basis through various approaches such that AI systems we create are capable of
+          self-modification while preserving goals.
+        seeAlso: a:agent_foundations
+        orthodoxProblems:
+          - "1"
+          - "4"
+        targetCase: worst-case
         broadApproaches:
           - cognitive
-        resources:
-          - title: MIRI Research
-            url: https://intelligence.org/research/
-          - title: Technical Agenda
-            url: https://intelligence.org/files/TechnicalAgenda.pdf
-      - id: tiling-agents
-        name: Tiling agents
-        lesswrongTags:
-          - tiling-agents
-        keywords:
-          - corrigibility
-          - decision-theory
-          - shutdown-resistance
-          - mesa-optimization
+        someNames:
+          - abram-demski
+        estimatedFTEs: 1-10
         papers:
           - title: Understanding Trust
-            url: https://static1.squarespace.com/static/663d1233249bce4815fe8753/t/68067a6f5d5fb0745642d5b1/1745255023842/Understanding+Trust+-+Abram+Demski.pdf
-            authors: Abram Demski, Norman Hsia, and Paul Rapoport
-          - title: earlier version
-            url: https://static1.squarespace.com/static/678814b5570c5a7a78df555d/t/67d09e3b1ae9ea24b0100509/1741725243695/Understanding_Trust__AFC_+-+Abram+Demski.pdf
+            url: >-
+              https://static1.squarespace.com/static/663d1233249bce4815fe8753/t/68067a6f5d5fb0745642d5b1/1745255023842/Understanding+Trust+-+Abram+Demski.pdf
+            authors: Abram Demski
+            kind: error_detected
           - title: Working through a small tiling result
             url: https://www.lesswrong.com/posts/akuMwu8SkmQSdospi/working-through-a-small-tiling-result
+            authors: James Payor
+            year: 2024
+            venue: LessWrong
+            kind: lesswrong
           - title: Communication & Trust
             url: https://openreview.net/forum?id=Rf1CeGPA22
             authors: Abram Demski
+            year: 2025
+            venue: ODYSSEY 2025 Conference
+            kind: paper_preprint
           - title: Maintaining Alignment during RSI as a Feedback Control Problem
             url: https://lesswrong.com/posts/PhgEKkB4cwYjwpGxb/maintaining-alignment-during-rsi-as-a-feedback-control
             authors: beren
-        summary: An aligned agent modifying itself into an unaligned agent would be bad and we can research ways that this could occur and infrastructure/approaches that prevent it from happening.
-        theoryOfChange: Build enough theoretical basis through various approaches such that AI agents we create are capable of self-modification while preserving goals.
-        seeAlso: "[Agent foundations](#agent-foundations-[cat:agent_foundations])"
-        orthodoxProblems:
-          - "1"
-          - "2"
-          - "4"
-        targetCase: worst-case
-        someNames:
-          - abram-demski
-        estimatedFTEs: 5?
-        broadApproaches:
-          - cognitive
-      - id: dovetail
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+      - id: theory_dovetail
         name: Dovetail
-        keywords:
-          - decision-theory
-          - abstractions
-          - ontology
-        papers:
-          - title: Report & retrospective on the Dovetail fellowship
-            url: https://www.lesswrong.com/posts/ApfjBbqzSu4aZoLSe/report-and-retrospective-on-the-dovetail-fellowship
-            authors: Alex Altair
-        summary: Formalize key ideas (“structure”, “agency”, etc) mathematically
-        theoryOfChange: generalize theorems → formalize agent foundations concepts like the agent structure problem → hopefully assist other projects through increased understanding
-        seeAlso: "[Agent foundations](#agent-foundations-[cat:agent_foundations])"
+        summary: Formalize key ideas ("structure", "agency", etc) mathematically.
+        theoryOfChange: >-
+          generalize theorems → formalize agent foundations concepts like the agent structure problem → hopefully assist
+          other projects through increased understanding
+        seeAlso: a:agent_foundations
         targetCase: pessimistic
         someNames:
           - alex-altair
@@ -2206,33 +4644,30 @@ sections:
           - daniel-c
           - dalcy-k
           - jos-pedro-faustino
-        estimatedFTEs: "2"
-        fundedBy:
-          - long-term-future-fund
-        broadApproaches:
-          - maths-philosophy
-      - id: high-actuation-spaces
-        name: High-Actuation Spaces
-        keywords:
-          - abstractions
-          - ontology
-          - goal-misgeneralization
+        estimatedFTEs: 1-5
         papers:
-          - title: https://openreview.net/forum?id=n7WYSJ35FU
-            url: https://openreview.net/forum?id=n7WYSJ35FU
-          - title: https://www.lesswrong.com/s/aMz2JMvgXrLBkq4h3
-            url: https://www.lesswrong.com/s/aMz2JMvgXrLBkq4h3
-          - title: https://docs.google.com/document/d/1d-ARdZZDHFPIfGcTTOKK8IZWlQj0NZQrmteJj2mvmYA/edit?tab=t.0\#heading=h.eg8luyrlsv2u
-            url: https://docs.google.com/document/d/1d-ARdZZDHFPIfGcTTOKK8IZWlQj0NZQrmteJj2mvmYA/edit?tab=t.0#heading=h.eg8luyrlsv2u
-          - title: https://drive.google.com/drive/folders/1EaAJ4szuZsYR2_-DkS9cuhx3S6IWeCjW
-            url: https://drive.google.com/drive/folders/1EaAJ4szuZsYR2_-DkS9cuhx3S6IWeCjW
-          - title: https://www.lesswrong.com/posts/tQ9vWm4b57HFqbaRj/what-if-not-agency
-            url: https://www.lesswrong.com/posts/tQ9vWm4b57HFqbaRj/what-if-not-agency
-          - title: Human Inductive Bias Project
-            url: https://docs.google.com/document/d/1fl7LE8AN7mLJ6uFcPuFCzatp0zCIYvjRIjQRgHPAkSE/edit?tab=t.0
-        summary: mechinterp and alignment assume a stable “computational substrate” (linear algebra on GPUs). If later AI uses different substrates (e.g. KAN, e.g. something neuromorphic), methods like probes and steering will not transfer. Therefore, better to try and infer goals via a "telic DAG" which abstracts over substrates, and so sidestep the issue of how to define intermediate representations. Category theory is intended to provide guarantees that this abstraction is valid.
-        theoryOfChange: sufficiently complex mindlike entities can alter their goals in ways that cannot be predicted or accounted for under substrate-dependent descriptions of the kind sought in mechanistic interpretability. use the telic DAG to define a method analogous to factoring a causal DAG.
-        seeAlso: "[Live theory](https://www.lesswrong.com/s/aMz2JMvgXrLBkq4h3), [MoSSAIC](https://openreview.net/forum?id=n7WYSJ35FU), Topos, [Agent foundations](#agent-foundations-[cat:agent_foundations])"
+          - title: Report & retrospective on the Dovetail fellowship
+            url: https://www.lesswrong.com/posts/ApfjBbqzSu4aZoLSe/report-and-retrospective-on-the-dovetail-fellowship
+            authors: Alex Altair
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+      - id: live_theory
+        name: High-Actuation Spaces
+        summary: >-
+          Mech interp and alignment assume a stable "computational substrate" (linear algebra on GPUs). If later AI uses
+          different substrates (e.g. something neuromorphic), methods like probes and steering will not transfer.
+          Therefore, better to try and infer goals via a "telic DAG" which abstracts over substrates, and so sidestep
+          the issue of how to define intermediate representations. Category theory is intended to provide guarantees
+          that this abstraction is valid.
+        theoryOfChange: >-
+          Sufficiently complex mindlike entities can alter their goals in ways that cannot be predicted or accounted for
+          under substrate-dependent descriptions of the kind sought in mechanistic interpretability. use the telic DAG
+          to define a method analogous to factoring a causal DAG.
+        seeAlso: >-
+          [Live theory](https://www.lesswrong.com/s/aMz2JMvgXrLBkq4h3),
+          [MoSSAIC](https://openreview.net/forum?id=n7WYSJ35FU), [Topos Institute](https://topos.institute/),
+          a:agent_foundations
         targetCase: pessimistic
         someNames:
           - sahil-k
@@ -2243,62 +4678,84 @@ sections:
           - jayson-amati
           - steve-petersen
           - topos
-          - TJ
-        estimatedFTEs: "2"
-        broadApproaches:
-          - maths-philosophy
+          - t-j
+        estimatedFTEs: 1-10
+        papers:
+          - title: https://groundless.ai/
+            url: https://groundless.ai/
+          - title: "MoSSAIC: AI Safety After Mechanism"
+            url: https://openreview.net/forum?id=n7WYSJ35FU
+            authors: Matt Farr, Aditya Arpitha Prasad, Chris Pang, Aditya Adiga, Jayson Amati, Sahil K
+            year: 2025
+            venue: ODYSSEY 2025 Conference
+            kind: paper_preprint
+          - title: "429: Too Many Requests"
+            url: https://www.lesswrong.com/s/aMz2JMvgXrLBkq4h3
+            venue: LessWrong
+            kind: error_detected
+          - title: High Actuation Spaces - Sahil
+            url: >-
+              https://docs.google.com/document/d/1d-ARdZZDHFPIfGcTTOKK8IZWlQj0NZQrmteJj2mvmYA/edit?tab=t.0#heading=h.eg8luyrlsv2u
+            authors: Sahil
+            venue: Google Docs
+            kind: error_detected
+          - title: HAS - Public (High Actuation Spaces)
+            url: https://drive.google.com/drive/folders/1EaAJ4szuZsYR2_-DkS9cuhx3S6IWeCjW
+            venue: Google Drive
+            kind: error_detected
+          - title: Unknown - Content Unavailable (429 Error)
+            url: https://www.lesswrong.com/posts/tQ9vWm4b57HFqbaRj/what-if-not-agency
+            venue: LessWrong
+            kind: error_detected
+          - title: HIBP Human Inductive Bias Project Plan
+            url: https://docs.google.com/document/d/1fl7LE8AN7mLJ6uFcPuFCzatp0zCIYvjRIjQRgHPAkSE/edit?tab=t.0
+            authors: Félix Dorn
+            venue: Google Docs
+            kind: error_detected
       - id: simulators
         name: Simulators
-        lesswrongTags:
-          - simulator-theory
-        keywords:
-          - personas
-          - world-models
-          - ontology
-        papers:
-          - title: A Three-Layer Model of LLM Psychology
-            url: https://www.alignmentforum.org/posts/zuXo9imNKYspu9HGv/a-three-layer-model-of-llm-psychology
-            authors: Jan Kulveit
-          - title: "Simulators vs Agents: Updating Risk Models"
-            url: https://www.lesswrong.com/s/pwKrMXjYNK5LNeKCu
-            authors: Will Petillo, Sean Herrington, Spencer Ames, Adebayo Mubarak, Can Narin
-        summary: Treat LLMs as a general simulator of sequences instead of as an agent. It effectively *roleplays* as a character or a statistical process. This is a counter-intuitive and hard to verify perspective, but yields different predictions.
-        theoryOfChange: Figure out the extent to which this framing matches current and future AI agent psychology, then use that to have less confused conversations and build safer models.
+        summary: >-
+          Treat LLMs as a general simulator of sequences instead of as a goal-maximising agent. It effectively
+          *roleplays* as a character or a statistical process. This is a counter-intuitive and hard to verify
+          perspective, but yields different predictions.
+        theoryOfChange: >-
+          Figure out the extent to which this framing matches current and future AI agent psychology, then use that to
+          have less confused conversations and build safer models.
         orthodoxProblems:
           - "4"
         targetCase: pessimistic
+        broadApproaches:
+          - cognitive
         someNames:
           - jan-kulveit
           - will-petillo
-        estimatedFTEs: 15?
-        broadApproaches:
-          - cognitive
-        resources:
-          - title: Simulators (LessWrong)
-            url: https://www.lesswrong.com/posts/vJFdjigzmcXMhNTsx/simulators
-      - id: asymptotic-guarantees
-        name: Asymptotic guarantees
-        keywords:
-          - scalable-oversight
-          - debate
-          - safety-cases
+        estimatedFTEs: 1-5
         papers:
-          - title: An alignment safety case sketch based on debate
-            url: https://lesswrong.com/posts/iELyAqizJkizBQbfr/an-alignment-safety-case-sketch-based-on-debate
-            authors: Marie_DB, Jacob Pfau, Benjamin Hilton et al.
-          - title: "UK AISI's Alignment Team: Research Agenda"
-            url: https://lesswrong.com/posts/tbnw7LbNApvxNLAg8/uk-aisi-s-alignment-team-research-agenda
-            authors: Benjamin Hilton, Jacob Pfau, Marie_DB et al.
-          - title: Dodging systematic human errors in scalable oversight
-            url: https://lesswrong.com/posts/EgRJtwQurNzz8CEfJ/dodging-systematic-human-errors-in-scalable-oversight
-            authors: Geoffrey Irving
-        summary: prove that if a safety process has enough resources (human data quality, training time, neural network capacity), then in the limit some system specification will be guaranteed. Use complexity theory, game theory, learning theory and other areas to both improve asymptotic guarantees and develop ways of showing convergence.
-        theoryOfChange: Formal verification may be too hard. Make safety cases stronger by modelling their processes and proving that they would work in the limit.
-        seeAlso: debate, control
+          - title: A Three-Layer Model of LLM Psychology
+            url: https://www.alignmentforum.org/posts/zuXo9imNKYspu9HGv/a-three-layer-model-of-llm-psychology%20
+            authors: Jan Kulveit
+            year: 2024
+            venue: AI Alignment Forum
+            kind: lesswrong
+          - title: "429: Too Many Requests"
+            url: https://www.lesswrong.com/s/pwKrMXjYNK5LNeKCu
+            venue: LessWrong
+            kind: error_detected
+      - id: aisi_guarantees
+        name: Asymptotic guarantees
+        summary: >-
+          Prove that if a safety process has enough resources (human data quality, training time, neural network
+          capacity), then in the limit some system specification will be guaranteed. Use complexity theory, game theory,
+          learning theory and other areas to both improve asymptotic guarantees and develop ways of showing convergence.
+        theoryOfChange: >-
+          Formal verification may be too hard. Make safety cases stronger by modelling their processes and proving that
+          they would work in the limit.
+        seeAlso: a:debate, a:control
         orthodoxProblems:
           - "4"
-          - "7"
         targetCase: pessimistic
+        broadApproaches:
+          - cognitive
         someNames:
           - aisi
           - jacob-pfau
@@ -2308,377 +4765,460 @@ sections:
           - will-kirby
           - martin-soto
           - david-africa
+          - davidad
         estimatedFTEs: 5 - 10
         critiques:
-          - "[UK AISI's Alignment Team: Research Agenda](https://lesswrong.com/posts/tbnw7LbNApvxNLAg8/uk-aisi-s-alignment-team-research-agenda)"
-        fundedBy:
-          - uk-aisi
-      - id: arc-theory
-        name: ARC Theory
-        lesswrongTags:
-          - alignment-research-center-arc
-          - eliciting-latent-knowledge
-        keywords:
-          - circuits
-          - deception
-          - probing
+          - >-
+            Self-critique in [UK AISI's Alignment Team: Research
+            Agenda](https://lesswrong.com/posts/tbnw7LbNApvxNLAg8/uk-aisi-s-alignment-team-research-agenda)
         papers:
-          - title: A computational no-coincidence principle
-            url: https://www.lesswrong.com/posts/Xt9r4SNNuYxW83tmo/a-computational-no-coincidence-principle
-          - title: Wide Neural Networks as a Baseline for the Computational No-Coincidence Conjecture
-            url: https://openreview.net/forum?id=m4OpQAK3eY
-          - title: "ARC progress update: Competing with sampling"
-            url: https://www.lesswrong.com/posts/XdQd9gELHakd5pzJA/arc-progress-update-competing-with-sampling
-          - title: Obstacles in ARC’s research agenda
-            url: https://www.lesswrong.com/s/uYMw689vDFmgPEHrS
-          - title: Acorn
-            url: https://acausal.org/
-        summary: Formalize mechanistic explanations of neural network behavior, automate the discovery of these “heuristic explanations” and use them to predict when novel input will lead to extreme behavior (Low Probability Estimation and Mechanistic Anomaly Detection).
-        theoryOfChange: push mech interp as far as it can be pushed, use heustic explanations for downstream tasks automatically, solve those downstream tasks well enough that Eliciting Latent Knowledge and deceptive alignment are solved.
-        seeAlso: ELK, mechanistic anomaly detection
+          - title: An alignment safety case sketch based on debate
+            url: https://lesswrong.com/posts/iELyAqizJkizBQbfr/an-alignment-safety-case-sketch-based-on-debate
+            authors: Marie_DB, Jacob Pfau, Benjamin Hilton, Geoffrey Irving
+            year: 2025
+            venue: LessWrong / AI Alignment Forum
+            kind: lesswrong
+          - title: "UK AISI's Alignment Team: Research Agenda"
+            url: https://lesswrong.com/posts/tbnw7LbNApvxNLAg8/uk-aisi-s-alignment-team-research-agenda
+            authors: Benjamin Hilton, Jacob Pfau, Marie_DB, Geoffrey Irving
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: Dodging systematic human errors in scalable oversight
+            url: https://lesswrong.com/posts/EgRJtwQurNzz8CEfJ/dodging-systematic-human-errors-in-scalable-oversight
+            authors: Geoffrey Irving
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+      - id: arc_theory_formal
+        name: Heuristic Explanations
+        summary: >-
+          Formalize mechanistic explanations of neural network behavior, automate the discovery of these "heuristic
+          explanations" and use them to predict when novel input will lead to extreme behavior (Low Probability
+          Estimation and Mechanistic Anomaly Detection).
+        theoryOfChange: >-
+          Push mech interp as far as it can be pushed, use formally rigorous heuristic explanations for downstream tasks
+          automatically, solve those downstream tasks well enough that Eliciting Latent Knowledge and deceptive
+          alignment are solved.
+        seeAlso: ARC Theory, ELK, mechanistic anomaly detection, [Acorn](https://acausal.org/)
         orthodoxProblems:
           - "4"
-          - "8"
-        targetCase: "*worst-case*"
+        targetCase: worst-case
         someNames:
-          - "*Jacob Hilton"
+          - jacob-hilton
           - mark-xu
           - eric-neyman
           - victor-lecomte
           - george-robinson
-        estimatedFTEs: "*(SR2024: 1-10)*"
+        estimatedFTEs: 1-10
         critiques:
           - "[Matolcsi](https://www.lesswrong.com/s/uYMw689vDFmgPEHrS)"
+        papers:
+          - title: A computational no-coincidence principle
+            url: https://www.lesswrong.com/posts/Xt9r4SNNuYxW83tmo/a-computational-no-coincidence-principle
+            authors: Eric Neyman
+            year: 2025
+            venue: LessWrong / AI Alignment Forum
+            kind: lesswrong
+          - title: Wide Neural Networks as a Baseline for the Computational No-Coincidence Conjecture
+            url: https://openreview.net/forum?id=m4OpQAK3eY
+            authors: John Dunbar, Scott Aaronson
+            year: 2025
+            venue: ODYSSEY 2025 Conference
+            kind: paper_preprint
+          - title: "ARC progress update: Competing with sampling"
+            url: https://www.lesswrong.com/posts/XdQd9gELHakd5pzJA/arc-progress-update-competing-with-sampling
+            authors: Eric Neyman
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: Obstacles in ARC's agenda
+            url: https://www.lesswrong.com/s/uYMw689vDFmgPEHrS
+            authors: David Matolcsi
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: Deduction-Projection Estimators for Understanding Neural Networks
+            url: https://gabrieldwu.com/assets/thesis.pdf
+      - id: learning_theoretic_agenda
+        name: The Learning-Theoretic Agenda
+        summary: >-
+          Try to formalise a more realistic agent, understand what it means for it to be aligned with us, translate
+          between its ontology and ours, and produce desiderata for a training setup that points at coherent AGIs
+          similar to our model of an aligned agent
+        theoryOfChange: Fix formal epistemology to work out how to avoid deep training problems
+        orthodoxProblems:
+          - "1"
+          - "4"
+        targetCase: worst-case
         broadApproaches:
           - cognitive
-          - maths-philosophy
-        resources:
-          - title: Alignment Research Center
-            url: https://www.alignment.org/
-        wikipedia: https://en.wikipedia.org/wiki/Alignment_Research_Center
-      - id: behavior-alignment-theory
-        name: Behavior alignment theory
-        lesswrongTags:
-          - shard-theory
-        keywords:
-          - corrigibility
-          - shutdown-resistance
-          - deception
-          - decision-theory
+        someNames:
+          - vanessa-kosoy
+          - diffractor
+          - gergely-szcs
+        estimatedFTEs: "3"
+        critiques:
+          - "[Matolcsi](https://www.lesswrong.com/posts/StkjjQyKwg7hZjcGB/a-mostly-critical-review-of-infra-bayesianism)"
         papers:
-          - title: Imitation learning is probably existentially safe
-            url: https://onlinelibrary.wiley.com/doi/10.1002/aaai.70040?af=R
-          - title: Preference gaps as a safeguard against AI self-replication
-            url: https://www.lesswrong.com/posts/knwR9RgGN5a2oorci/preference-gaps-as-a-safeguard-against-ai-self-replication
-            authors: Elliott Thornley, tbs
-          - title: Serious Flaws in CAST
-            url: https://www.lesswrong.com/s/KfCjeconYRdFbMxsy/p/qgBFJ72tahLo5hzqy
-            authors: Max Harms, 2025-11-19,
-          - title: Model-Based Soft Maximization of Suitable Metrics of Long-Term Human Power
-            url: https://arxiv.org/abs/2508.00159
-            authors: Jobst Heitzig, Ram Potham
-          - title: "A Safety Case for a Deployed LLM: Corrigibility as a Singular Target"
-            url: https://openreview.net/forum?id=mhEnJa9pNk
-            authors: Ram Potham
-          - title: Shutdownable Agents through POST-Agency
-            url: https://arxiv.org/abs/2505.20203
-            authors: Elliott Thornley
-          - title: The Partially Observable Off-Switch Game
-            url: https://arxiv.org/abs/2411.17749
-            authors: Andrew Garber, Rohan Subramani, Linus Luu et al.
-          - title: Deceptive Alignment and Homuncularity
-            url: https://lesswrong.com/posts/9htmQx5wiePqTtZuL/deceptive-alignment-and-homuncularity
-            authors: Oliver Sourbut, TurnTrout
-          - title: LLM AGI will have memory, and memory changes alignment
-            url: https://lesswrong.com/posts/aKncW36ZdEnzxLo8A/llm-agi-will-have-memory-and-memory-changes-alignment
-            authors: Seth Herd
-        summary: Predict properties of future AGI (e.g. power-seeking) with formal models; formally state and prove hypotheses about the properties powerful systems will have and how we might try to change them
-        theoryOfChange: Figure out hypotheses about properties powerful agents will have → attempt to rigorously prove under what conditions the hypotheses hold → test these hypotheses where feasible → design training environments that lead to more salutary properties
-        seeAlso: Agent Foundations, control.
+          - title: "New paper: Infra-Bayesian Decision Estimation Theory"
+            url: https://www.lesswrong.com/posts/LgLez8aeK24PbyyQJ/new-paper-infra-bayesian-decision-estimation-theory
+            venue: LessWrong
+            kind: error_detected
+          - title: Infra-Bayesianism
+            url: https://www.lesswrong.com/w/infra-bayesianism?sortedBy=new
+            authors: abramdemski, Ruby
+            year: 2022
+            venue: LessWrong
+            kind: lesswrong
+          - title: "New Paper: Ambiguous Online Learning"
+            url: https://www.lesswrong.com/posts/Y9NuKpb6dsyiYFxWK/new-paper-ambiguous-online-learning
+            authors: Vanessa Kosoy
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: Regret Bounds for Robust Online Decision Making
+            url: https://proceedings.mlr.press/v291/appel25a.html
+          - title: "What is Inadequate about Bayesianism for AI Alignment: Motivating Infra-Bayesianism"
+            url: https://www.lesswrong.com/s/n7qFxakSnxGuvmYAX
+          - title: Non-Monotonic Infra-Bayesian Physicalism
+            url: https://www.alignmentforum.org/posts/DobZ62XMdiPigii9H/non-monotonic-infra-bayesian-physicalism%20
+            authors: Marcus Ogren
+            year: 2025
+            venue: AI Alignment Forum
+            kind: lesswrong
+      - id: behavior_alignment_theory
+        name: Behavior alignment theory
+        summary: >-
+          Predict properties of future AGI (e.g. power-seeking) with formal models; formally state and prove hypotheses
+          about the properties powerful systems will have and how we might try to change them.
+        theoryOfChange: >-
+          Figure out hypotheses about properties powerful agents will have → attempt to rigorously prove under what
+          conditions the hypotheses hold → test these hypotheses where feasible → design training environments that lead
+          to more salutary properties.
+        seeAlso: a:agent_foundations, a:control
         orthodoxProblems:
-          - "2"
           - "5"
         targetCase: worst-case
         someNames:
           - ram-potham
           - michael-k-cohen
-          - "* Max Harms/Raelifin*"
-          - "* John Wentworth*"
-          - "* David Lorell*"
-          - "* Elliott Thornley"
-        estimatedFTEs: 1-10?
+          - max-harmsraelifin
+          - john-wentworth
+          - david-lorell
+          - elliott-thornley
+        estimatedFTEs: 1-10
         critiques:
-          - "[Ryan Greenblatt’s criticism](https://www.lesswrong.com/posts/YbEbwYWkf8mv9jnmi/the-shutdown-problem-incomplete-preferences-as-a-solution?commentId=GJAippZ6ZzCagSnDb)"
-        broadApproaches:
-          - maths-philosophy
-      - id: other-corrigibility
-        name: Other corrigibility
-        lesswrongTags:
-          - corrigibility-1
-        keywords:
-          - corrigibility
-          - shutdown-resistance
-          - goal-misgeneralization
-          - power-seeking
-          - inner-alignment
+          - >-
+            [Ryan Greenblatt's
+            criticism](https://www.lesswrong.com/posts/YbEbwYWkf8mv9jnmi/the-shutdown-problem-incomplete-preferences-as-a-solution?commentId=GJAippZ6ZzCagSnDb)
+            of one behavioral proposal
         papers:
-          - title: AI Assistants Should Have a Direct Line to Their Developers
-            url: https://www.lesswrong.com/posts/LDYPF6yfe3f8SPHFT/ai-assistants-should-have-a-direct-line-to-their-developers
-          - title: Testing for Scheming with Model Deletion
-            url: https://www.lesswrong.com/posts/D5kGGGhsnfH7G8v9f/testing-for-scheming-with-model-deletion
-          - title: Detect Goodhart and shut down
-            url: https://www.lesswrong.com/posts/ZHFZ6tivEjznkEoby/detect-goodhart-and-shut-down
-            authors: Jeremy Gillen
-          - title: Instrumental Goals Are A Different And Friendlier Kind Of Thing Than Terminal Goals
-            url: https://www.lesswrong.com/posts/7Z4WC4AFgfmZ3fCDC/instrumental-goals-are-a-different-and-friendlier-kind-of
-            authors: John Wentworth, David Lorell
+          - title: Imitation learning is probably existentially safe
+            url: https://onlinelibrary.wiley.com/doi/10.1002/aaai.70040?af=R
+            authors: Michael K. Cohen, Marcus Hutter
+            year: 2025
+            venue: AI Magazine
+            kind: paper_published
+          - title: Preference gaps as a safeguard against AI self-replication
+            url: >-
+              https://www.lesswrong.com/posts/knwR9RgGN5a2oorci/preference-gaps-as-a-safeguard-against-ai-self-replication
+            authors: tbs, EJT
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: Serious Flaws in CAST
+            url: https://www.lesswrong.com/s/KfCjeconYRdFbMxsy/p/qgBFJ72tahLo5hzqy
+            authors: Max Harms
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: Model-Based Soft Maximization of Suitable Metrics of Long-Term Human Power
+            url: https://arxiv.org/abs/2508.00159
+            authors: Jobst Heitzig, Ram Potham
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "A Safety Case for a Deployed LLM: Corrigibility as a Singular Target"
+            url: https://openreview.net/forum?id=mhEnJa9pNk
+            authors: Ram Potham
+            year: 2025
+            venue: ODYSSEY 2025 Conference
+            kind: paper_preprint
           - title: Shutdownable Agents through POST-Agency
-            url: https://www.lesswrong.com/posts/JuRdvZyqaFbvTPemn/shutdownable-agents-through-post-agency-1
-            authors: EJT
-          - title: Why Corrigibility is Hard and Important (i.e. "Whence the high MIRI confidence in alignment difficulty?")
-            url: https://www.lesswrong.com/posts/ksfjZJu3BFEfM6hHE/why-corrigibility-is-hard-and-important-i-e-whence-the-high
-            authors: Raemon, Eliezer Yudkowsky, So8res
-          - title: Problems with instruction-following as an alignment target
-            url: https://lesswrong.com/posts/CSFa9rvGNGAfCzBk6/problems-with-instruction-following-as-an-alignment-target
+            url: https://arxiv.org/abs/2505.20203
+            authors: Elliott Thornley
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: The Partially Observable Off-Switch Game
+            url: https://arxiv.org/abs/2411.17749
+            authors: Andrew Garber, Rohan Subramani, Linus Luu, Mark Bedaywi, Stuart Russell, Scott Emmons
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: Deceptive Alignment and Homuncularity
+            url: https://lesswrong.com/posts/9htmQx5wiePqTtZuL/deceptive-alignment-and-homuncularity
+            authors: Oliver Sourbut, TurnTrout
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: LLM AGI will have memory, and memory changes alignment
+            url: https://lesswrong.com/posts/aKncW36ZdEnzxLo8A/llm-agi-will-have-memory-and-memory-changes-alignment
             authors: Seth Herd
-        summary: Diagnose and communicate obstacles to achieving robustly corrigible behavior; suggest mechanisms, tests, and escalation channels for surfacing and mitigating incorrigible behaviors
-        theoryOfChange: Labs are likely to develop AGI using something analogous to current pipelines. Clarifying why naive instruction-following doesn’t buy robust corrigibility \+ building strong tripwires/diagnostics for scheming and Goodharting thus reduces risks on the likely default path.
-        seeAlso: Behavior alignment theory
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: A Shutdown Problem Proposal
+            url: https://www.lesswrong.com/posts/PhTBDHu9PKJFmvb4p/a-shutdown-problem-proposal
+            authors: johnswentworth, David Lorell
+            year: 2024
+            venue: LessWrong
+            kind: lesswrong
+      - id: corrigibility_other
+        name: Other corrigibility
+        summary: >-
+          Diagnose and communicate obstacles to achieving robustly corrigible behavior; suggest mechanisms, tests, and
+          escalation channels for surfacing and mitigating incorrigible behaviors
+        theoryOfChange: >-
+          Labs are likely to develop AGI using something analogous to current pipelines. Clarifying why naive
+          instruction-following doesn't buy robust corrigibility + building strong tripwires/diagnostics for scheming
+          and Goodharting thus reduces risks on the likely default path.
+        seeAlso: a:behavior_alignment_theory
         orthodoxProblems:
-          - "2"
           - "5"
         targetCase: pessimistic
         someNames:
-          - "*Jan Kulveit"
+          - jan-kulveit
           - jeremy-gillen
-        estimatedFTEs: 1-5?
-        broadApproaches:
-          - engineering
-          - maths-philosophy
-      - id: natural-abstractions
-        name: Natural abstractions
-        lesswrongTags:
-          - natural-abstraction
-        keywords:
-          - abstractions
-          - ontology
-          - features
-          - world-models
+        estimatedFTEs: 1-10
         papers:
-          - title: "Natural Latents: Latent Variables Stable Across Ontologies"
-            url: https://arxiv.org/abs/2509.03780
-            authors: John Wentworth, David Lorell
-          - title: Abstract Mathematical Concepts vs. Abstractions Over Real-World Systems
-            url: https://www.lesswrong.com/posts/T6xSXiXF3WF6TmCyN/abstract-mathematical-concepts-vs-abstractions-over-real
-            authors: Thane Ruthenis
-          - title: "Condensation: a theory of concepts"
-            url: https://openreview.net/forum?id=HwKFJ3odui
-            authors: Sam Eisenstat
-          - title: Getting aligned on representational alignment
-            url: https://arxiv.org/abs/2310.13018
-          - title: Platonic representation hypothesis
-            url: https://phillipi.github.io/prh/
-          - title: Rosas
-            url: https://www.youtube.com/watch?v=Nr9eMobqUOo&t=3s
-        summary: check the hypothesis that our universe "abstracts well" and that many cognitive systems learn to use similar abstractions. Check if features correspond to small causal diagrams corresponding to linguistic constructions
-        theoryOfChange: "find all possible abstractions of a given computation → translate them into human-readable language → identify useful ones like deception → intervene when a model is using it. Also develop theory for interp more broadly; more mathematical analysis. Also maybe enables \"retargeting the search\": identifying \"utility function\" components inside the AI and replacing calls to it with calls to \"user values\" (represented using existing abstractions inside the AI)."
-        seeAlso: causal abstractions, representational alignment, convergent abstractions, feature universality, Platonic representation hypothesis
+          - title: AI Assistants Should Have a Direct Line to Their Developers
+            url: >-
+              https://www.lesswrong.com/posts/LDYPF6yfe3f8SPHFT/ai-assistants-should-have-a-direct-line-to-their-developers
+            authors: Jan_Kulveit
+            year: 2024
+            venue: LessWrong / AI Alignment Forum
+            kind: lesswrong
+          - title: Testing for Scheming with Model Deletion
+            url: https://www.lesswrong.com/posts/D5kGGGhsnfH7G8v9f/testing-for-scheming-with-model-deletion
+            venue: LessWrong
+            kind: error_detected
+          - title: Detect Goodhart and shut down
+            url: https://www.lesswrong.com/posts/ZHFZ6tivEjznkEoby/detect-goodhart-and-shut-down
+            authors: Jeremy Gillen
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: Instrumental goals are a different and friendlier kind of [content unavailable]
+            url: >-
+              https://www.lesswrong.com/posts/7Z4WC4AFgfmZ3fCDC/instrumental-goals-are-a-different-and-friendlier-kind-of
+            venue: LessWrong
+            kind: error_detected
+          - title: Shutdownable Agents through POST-Agency
+            url: https://www.lesswrong.com/posts/JuRdvZyqaFbvTPemn/shutdownable-agents-through-post-agency-1
+            authors: EJT
+            year: 2025
+            venue: LessWrong/AI Alignment Forum
+            kind: lesswrong
+          - title: "Error: Content Unavailable - Too Many Requests (429)"
+            url: >-
+              https://www.lesswrong.com/posts/ksfjZJu3BFEfM6hHE/why-corrigibility-is-hard-and-important-i-e-whence-the-high
+            venue: LessWrong
+            kind: error_detected
+          - title: Problems with instruction-following as an alignment target
+            url: https://lesswrong.com/posts/CSFa9rvGNGAfCzBk6/problems-with-instruction-following-as-an-alignment-target
+            authors: Seth Herd
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: "Oblivious Defense in ML Models: Backdoor Removal without Detection"
+            url: https://dl.acm.org/doi/10.1145/3717823.3718245
+          - title: "Cryptographic Backdoor for Neural Networks: Boon and Bane"
+            url: https://arxiv.org/abs/2509.20714
+          - title: A Cryptographic Perspective on Mitigation vs. Detection in Machine Learning
+            url: https://arxiv.org/abs/2504.20310
+      - id: natural_abstractions
+        name: Natural abstractions
+        summary: >-
+          Develop a theory of concepts that explains how they are learned, how they structure a particular system's
+          understanding, and how mutual translatability can be achieved between different collections of concepts.
+        theoryOfChange: >-
+          Understand the concepts a system's understanding is structured with and use them to inspect its
+          "alignment/safety properties" and/or "retarget its search", i.e. identify utility-function-like components
+          inside an AI and replacing calls to them with calls to "user values" (represented using existing abstractions
+          inside the AI).
+        seeAlso: >-
+          a:interp_causal_abstractions, representational alignment, convergent abstractions, feature universality,
+          Platonic representation hypothesis, microscope AI
         orthodoxProblems:
           - "5"
-          - "7"
-          - "9"
-        targetCase: "SR2024: worst-case"
+        targetCase: worst-case
+        broadApproaches:
+          - cognitive
         someNames:
           - john-wentworth
           - paul-colognese
           - david-lorrell
           - sam-eisenstat
-        estimatedFTEs: "*(SR2024: 1-10)*"
-        fundedBy:
-          - ea-funds
-        broadApproaches:
-          - cognitive
-        resources:
-          - title: Natural Abstraction Hypothesis (LessWrong)
-            url: https://www.lesswrong.com/posts/Fut8dtFsBYRz8atFF/the-natural-abstraction-hypothesis-implications-and-evidence
-          - title: AXRP Podcast Episode
-            url: https://axrp.net/episode/2022/05/23/episode-15-natural-abstractions-john-wentworth.html
-      - id: other-ontology-work
-        name: Other ontology work
-        lesswrongTags:
-          - ontology
-        keywords:
-          - ontology
-          - abstractions
-          - world-models
-          - features
+        estimatedFTEs: 1-10
+        critiques:
+          - >-
+            [Chan et al
+            (2023)](https://www.lesswrong.com/posts/gvzW46Z3BsaZsLc25/natural-abstractions-key-claims-theorems-and-critiques-1#3__A_formalization_of_abstractions_would_accelerate_alignment_research),
+            [Soto](https://www.lesswrong.com/posts/CJjT8GMitsnKc2wgG/natural-abstractions-are-observer-dependent-a-conversation-1),
+            [Harwood](https://www.lesswrong.com/posts/F4nzox6oh5oAdX9D3/abstractions-are-not-natural), [Soares
+            (2023)](https://www.lesswrong.com/posts/mgjHS6ou7DgwhKPpu/a-rough-and-incomplete-review-of-some-of-john-wentworth-s)
         papers:
+          - title: "Natural Latents: Latent Variables Stable Across Ontologies"
+            url: https://arxiv.org/abs/2509.03780
+            authors: John Wentworth, David Lorell
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Abstract mathematical concepts vs abstractions over real
+            url: https://www.lesswrong.com/posts/T6xSXiXF3WF6TmCyN/abstract-mathematical-concepts-vs-abstractions-over-real
+            venue: LessWrong
+            kind: error_detected
+          - title: "Condensation: a theory of concepts"
+            url: https://openreview.net/forum?id=HwKFJ3odui
+            authors: Sam Eisenstat
+            year: 2025
+            venue: ODYSSEY 2025 Conference
+            kind: paper_preprint
+          - title: Condensation
+            url: https://www.lesswrong.com/posts/BstHXPgQyfeNnLjjp/condensation
+            authors: abramdemski
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: Getting aligned on representational alignment
+            url: https://arxiv.org/abs/2310.13018
+            authors: >-
+              Ilia Sucholutsky, Lukas Muttenthaler, Adrian Weller, Andi Peng, Andreea Bobu, Been Kim, Bradley C. Love,
+              Christopher J. Cueva, Erin Grant, Iris Groen, Jascha Achterberg, Joshua B. Tenenbaum, Katherine M.
+              Collins, Katherine L. Hermann, Kerem Oktar, Klaus Greff, Martin N. Hebart, Nathan Cloos, Nikolaus
+              Kriegeskorte, Nori Jacoby, Qiuyi Zhang, Raja Marjieh, Robert Geirhos, Sherol Chen, Simon Kornblith,
+              Sunayana Rane, Talia Konkle, Thomas P. O'Connell, Thomas Unterthiner, Andrew K. Lampinen, Klaus-Robert
+              Müller, Mariya Toneva, Thomas L. Griffiths
+            year: 2023
+            venue: arXiv
+            kind: paper_preprint
+          - title: The Platonic Representation Hypothesis
+            url: https://phillipi.github.io/prh/
+            authors: Minyoung Huh, Brian Cheung, Tongzhou Wang, Phillip Isola
+            year: 2024
+            venue: ICML 2024
+            kind: paper_published
+          - title: "Fernando Rosas: Identifying Abstractions (HAAISS 2025)"
+            url: https://www.youtube.com/watch?v=Nr9eMobqUOo&t=3s
+            authors: Fernando Rosas
+            year: 2025
+            venue: HAAISS 2025
+            kind: error_detected
           - title: "Factored space models: Towards causality between levels of abstraction"
             url: https://arxiv.org/abs/2412.02579
+            authors: Scott Garrabrant, Matthias Georg Mayer, Magdalena Wache, Leon Lang, Sam Eisenstat, Holger Dell
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
           - title: A single principle related to many Alignment subproblems?
             url: https://lesswrong.com/posts/h89L5FMAkEBNsZ3xM/a-single-principle-related-to-many-alignment-subproblems-2
-        summary: ""
-        theoryOfChange: ""
-        targetCase: ""
-        estimatedFTEs: ""
-      - id: the-learning-theoretic-agenda
-        name: The Learning-Theoretic Agenda
-        keywords:
-          - decision-theory
-          - ontology
-          - goal-misgeneralization
-        papers:
-          - title: Infra-Bayesian Decision-Estimation Theory
-            url: https://www.lesswrong.com/posts/LgLez8aeK24PbyyQJ/new-paper-infra-bayesian-decision-estimation-theory
-            authors: Vanessa Kosoy, Diffractor
-          - title: Infra-Bayesianism category on LessWrong
-            url: https://www.lesswrong.com/w/infra-bayesianism?sortedBy=new
-          - title: Ambiguous Online Learning
-            url: https://www.lesswrong.com/posts/Y9NuKpb6dsyiYFxWK/new-paper-ambiguous-online-learning
-            authors: Vanessa Kosoy
-          - title: Regret Bounds for Robust Online Decision Making
-            url: https://arxiv.org/abs/2504.06820
-            authors: Alexander Appel, Vanessa Kosoy
-          - title: "What is Inadequate about Bayesianism for AI Alignment: Motivating Infra-Bayesianism"
-            url: https://lesswrong.com/posts/wzCtwYtojMabyEg2L/what-is-inadequate-about-bayesianism-for-ai-alignment
-            authors: Brittany Gelb
-        summary: try to formalise a more realistic agent, understand what it means for it to be aligned with us, translate between its ontology and ours, and produce desiderata for a training setup that points at coherent AGIs similar to our model of an aligned agent
-        theoryOfChange: fix formal epistemology to work out how to avoid deep training problems
-        orthodoxProblems:
-          - "1"
-          - "9"
-        targetCase: worst-case
-        someNames:
-          - vanessa-kosoy
-          - diffractor
-        estimatedFTEs: "3"
-        critiques:
-          - "[Matolcsi](https://www.lesswrong.com/posts/StkjjQyKwg7hZjcGB/a-mostly-critical-review-of-infra-bayesianism)"
-        fundedBy:
-          - ea-funds
-          - survival-flourishing-fund
-          - aria
-          - uk-aisi
-        broadApproaches:
-          - cognitive
-      - id: uncategorised
-        name: Uncategorised
-        papers:
-          - title: Superposition Yields Robust Neural Scaling
-            url: https://arxiv.org/abs/2505.10465
-          - title: Training Dynamics of In-Context Learning in Linear Attention
-            url: https://arxiv.org/abs/2501.16265
-          - title: General agents contain world models
-            url: https://arxiv.org/abs/2506.01622
-          - title: The Limits of Predicting Agents from Behaviour
-            url: https://arxiv.org/abs/2506.02923
-          - title: Measuring Goal-Directedness
-            url: https://arxiv.org/abs/2412.04758
-          - title: How do we solve the alignment problem?
-            url: https://lesswrong.com/posts/fMqgLGoeZFFQqAGyC/how-do-we-solve-the-alignment-problem
-          - title: Plans A, B, C, and D for misalignment risk
-            url: https://lesswrong.com/posts/E8n93nnEaFeXTbHn5/plans-a-b-c-and-d-for-misalignment-risk
-          - title: What is it to solve the alignment problem?
-            url: https://lesswrong.com/posts/syEwQzC6LQywQDrFi/what-is-it-to-solve-the-alignment-problem-2
-          - title: AI for AI safety
-            url: https://lesswrong.com/posts/F3j4xqpxjxgQD3xXh/ai-for-ai-safety
-          - title: AI Safety x Physics Grand Challenge
-            url: https://lesswrong.com/posts/qSDvzyh7LgsAJfehk/ai-safety-x-physics-grand-challenge
-          - title: We won't get AIs smart enough to solve alignment but too dumb to rebel
-            url: https://lesswrong.com/posts/8buEtNxCScYpjzgW8/we-won-t-get-ais-smart-enough-to-solve-alignment-but-too
-          - title: "ASI existential risk: Reconsidering Alignment as a Goal"
-            url: https://lesswrong.com/posts/YeQe36XiY4BhrtRh5/asi-existential-risk-reconsidering-alignment-as-a-goal-1
-          - title: Legible vs. Illegible AI Safety Problems
-            url: https://lesswrong.com/posts/PMc65HgRFvBimEpmJ/legible-vs-illegible-ai-safety-problems
-          - title: Paths and waystations in AI safety
-            url: https://lesswrong.com/posts/kBgySGcASWa4FWdD9/paths-and-waystations-in-ai-safety-1
-          - title: Definition of alignment science I like
-            url: https://lesswrong.com/posts/mk3qkvBv8ciFeXGdL/definition-of-alignment-science-i-like
-          - title: Two alignment threat models
-            url: https://aligned.substack.com/p/two-alignment-threat-models?isFreemail=true&post_id=151342016&publication_id=328633&r=67wny&triedRedirect=true
-          - title: Can we safely automate alignment research?
-            url: https://lesswrong.com/posts/nJcuj4rtuefeTRFHp/can-we-safely-automate-alignment-research
-  - id: multi-agent-first
+            authors: Q Home
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+  - id: multi_agent_first
     name: Multi-agent first
-    description: Multi-agent approaches to alignment
     agendas:
-      - id: alignment-to-context
-        name: Alignment to context
-        keywords:
-          - rlhf
-          - corrigibility
-          - value-specification
-          - personas
-        papers:
-          - title: Beyond Preferences in AI Alignment
-            url: https://arxiv.org/abs/2408.16984
-          - title: 2404.10636 - What are human values, and how do we align AI to them?
-            url: https://arxiv.org/abs/2404.10636
-          - title: 2503.00940 - Can AI Model the Complexities of Human Moral Decision-Making? A Qualitative Study of Kidney Allocation Decisions
-            url: https://arxiv.org/abs/2503.00940
-          - title: The Frame-Dependent Mind
-            url: https://www.softmax.com/blog/the-frame-dependent-mind
-          - title: Model Integrity
-            url: https://meaningalignment.substack.com/p/model-integrity
-          - title: On Eudaimonia and Optimization
-            url: https://docs.google.com/document/d/1cKbqYSGspfJavXvnhsp3mAuxHh08rNbP7tzYieqLiXw/edit?tab=t.0
-          - title: Full-Stack Alignment
-            url: https://www.full-stack-alignment.ai
-        summary: Align AI directly to the role of participant-in, collaborator-for, or adviser-to our best-endorsed real human practices and institutions, instead of aligning AI to separately representable goals, rules, or utility functions
-        theoryOfChange: Many classical problems in AGI alignment are downstream of a type error about human values. Operationalizing a correct view of human values -- one that treats human values as impossible or impractical to abstract from concrete human practices and institutions -- will unblock value fragility, goal-misgeneralization, instrumental convergence, and pivotal-act specification
-        seeAlso: Aligning what? Aligned to who?
+      - id: alignment_to_context
+        name: Aligning to context
+        summary: >-
+          Align AI directly to the role of participant, collaborator, or advisor for our best real human practices and
+          institutions, instead of aligning AI to separately representable goals, rules, or utility functions.
+        theoryOfChange: >-
+          "Many classical problems in AGI alignment are downstream of a type error about human values." Operationalizing
+          a correct view of human values - one that treats human values as impossible or impractical to abstract from
+          concrete practices - will unblock value fragility, goal-misgeneralization, instrumental convergence, and
+          pivotal-act specification.
+        seeAlso: a:aligning_what, a:aligned_to_who
         orthodoxProblems:
           - "1"
-          - "2"
           - "4"
           - "5"
-          - "13"
-        targetCase: Mixed
+        broadApproaches:
+          - behavioral
         someNames:
+          - full-stack-alignment
           - meaning-alignment-institute
+          - plurality-institute
           - tan-zhi-xuan
           - matija-franklin
           - ryan-lowe
           - joe-edelman
           - oliver-klingefjord
-          - full-stack-alignment
         estimatedFTEs: "5"
-        fundedBy:
-          - aria
-          - openai
-          - survival-flourishing-fund
-        broadApproaches:
-          - behavioral
-      - id: aligning-to-the-social-contract
-        name: Aligning to the social contract
-        keywords:
-          - game-theory
-          - multi-agent
-          - corrigibility
-          - value-specification
         papers:
-          - title: "Law-Following AI: designing AI agents to obey human laws"
-            url: https://law-ai.org/law-following-ai/
-          - title: 2506.17434 - Resource Rational Contractualism Should Guide AI Alignment
-            url: https://arxiv.org/abs/2506.17434
-          - title: 2509.07955 - ACE and Diverse Generalization via Selective Disagreement
-            url: https://arxiv.org/abs/2509.07955
-          - title: "Promises Made, Promises Kept: Safe Pareto Improvements via Ex Post Verifiable Commitments"
-            url: https://arxiv.org/abs/2505.00783
-          - title: 2408.16984 - Beyond Preferences in AI Alignment
+          - title: Beyond Preferences in AI Alignment
             url: https://arxiv.org/abs/2408.16984
-          - title: Societal alignment frameworks can improve llm alignment
-            url: https://arxiv.org/abs/2503.00069
-        summary: Generate AIs’ operational values from ‘social contract’-style ideal civic deliberation formalisms and their consequent rulesets for civic actors
-        theoryOfChange: Formalize and apply the liberal tradition's project of defining civic principles separable from the substantive good, aligning our AIs to civic principles that bypass fragile utility-learning and intractable utility-calculation
-        seeAlso: Alignment to context,  Aligning what
+            authors: Tan Zhi-Xuan, Micah Carroll, Matija Franklin, Hal Ashton
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: What are human values, and how do we align AI to them?
+            url: https://arxiv.org/abs/2404.10636
+            authors: Oliver Klingefjord, Ryan Lowe, Joe Edelman
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: >-
+              Can AI Model the Complexities of Human Moral Decision-Making? A Qualitative Study of Kidney Allocation
+              Decisions
+            url: https://arxiv.org/abs/2503.00940
+            authors: >-
+              Vijay Keswani, Vincent Conitzer, Walter Sinnott-Armstrong, Breanna K. Nguyen, Hoda Heidari, Jana Schaich
+              Borg
+            year: 2025
+            venue: ACM CHI 2025
+            kind: paper_published
+          - title: "The Frame-Dependent Mind: On Reality's Stubborn Refusal To Be One Thing"
+            url: https://www.softmax.com/blog/the-frame-dependent-mind
+            authors: Emmett Shear, Sonnet 3.7
+            year: 2025
+            venue: Softmax Blog
+            kind: blog_post
+          - title: Model Integrity
+            url: https://meaningalignment.substack.com/p/model-integrity
+            authors: Joe Edelman, Oliver Klingefjord
+            year: 2024
+            venue: Substack
+            kind: blog_post
+          - title: On Eudaimonia and Optimization
+            url: https://docs.google.com/document/d/1cKbqYSGspfJavXvnhsp3mAuxHh08rNbP7tzYieqLiXw/edit?tab=t.0%20
+            venue: Google Docs
+            kind: error_detected
+          - title: "Full-Stack Alignment: Co-Aligning AI and Institutions with Thick Models of Value"
+            url: https://www.full-stack-alignment.ai
+            kind: personal_page
+          - title: https://arxiv.org/abs/2412.19010
+            url: https://arxiv.org/abs/2412.19010
+      - id: contractualist_alignment
+        name: Aligning to the social contract
+        summary: >-
+          Generate AIs' operational values from 'social contract'-style ideal civic deliberation formalisms and their
+          consequent rulesets for civic actors
+        theoryOfChange: >-
+          Formalize and apply the liberal tradition's project of defining civic principles separable from the
+          substantive good, aligning our AIs to civic principles that bypass fragile utility-learning and intractable
+          utility-calculation
+        seeAlso: a:alignment_to_context, a:aligning_what
         orthodoxProblems:
           - "1"
           - "4"
           - "5"
           - "10"
-          - "13"
-        targetCase: Mixed
+        broadApproaches:
+          - cognitive
         someNames:
           - gillian-hadfield
           - tan-zhi-xuan
@@ -2686,98 +5226,140 @@ sections:
           - matija-franklin
           - joshua-b-tenenbaum
         estimatedFTEs: 5 - 10
-        fundedBy:
-          - google-deepmind
-        broadApproaches:
-          - cognitive
-      - id: aligning-multiple-ais-game-theory
-        name: "Aligning multiple AIs: game theory"
-        lesswrongTags:
-          - game-theory
-          - multipolar-scenarios
-        keywords:
-          - game-theory
-          - multi-agent
-          - decision-theory
         papers:
-          - title: 2502.14143 - Multi-Agent Risks from Advanced AI
-            url: https://arxiv.org/abs/2502.14143
-          - title: 2503.06323 - Higher-Order Belief in Incomplete Information MAIDs
-            url: https://arxiv.org/abs/2503.06323
-          - title: AI Testing Should Account for Sophisticated Strategic Behaviour
-            url: https://arxiv.org/abs/2508.14927
-          - title: Characterising Simulation-Based Program Equilibria
-            url: https://arxiv.org/abs/2412.14570
-          - title: "Strategic Intelligence in Large Language Models: Evidence from evolutionary Game Theory"
-            url: https://arxiv.org/abs/2507.02618
-          - title: Communication Enables Cooperation in LLM Agents
-            url: https://arxiv.org/abs/2510.05748
-          - title: Emergent social conventions and collective bias in LLM populations
-            url: https://www.science.org/doi/10.1126/sciadv.adu9368
-          - title: An Economy of AI Agents
-            url: https://arxiv.org/abs/2509.01063
-        summary: Use realistic game-theory variants (e.g. evolutionary game theory, computational game theory) to describe/predict the collective and individual behaviours of AI agents in multi-agent scenarios
-        theoryOfChange: While traditional AGI safety focuses on idealized decision-theory and individual agents, it’s plausible that strategic AI agents will first emerge (or are emerging now) in a complex, multi-AI strategic landscape. We need granular, realistic formal models of AIs’ strategic interactions and collective dynamics to understand this future
-        seeAlso: "Aligning multiple AIs: tools and techniques, Aligning what"
+          - title: "Law-Following AI: designing AI agents to obey human laws"
+            url: https://law-ai.org/law-following-ai/%20
+          - title: Resource Rational Contractualism Should Guide AI Alignment
+            url: https://arxiv.org/abs/2506.17434
+            authors: >-
+              Sydney Levine, Matija Franklin, Tan Zhi-Xuan, Secil Yanik Guyot, Lionel Wong, Daniel Kilov, Yejin Choi,
+              Joshua B. Tenenbaum, Noah Goodman, Seth Lazar, Iason Gabriel
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: ACE and Diverse Generalization via Selective Disagreement
+            url: https://arxiv.org/abs/2509.07955
+            authors: >-
+              Oliver Daniels, Stuart Armstrong, Alexandre Maranhão, Mahirah Fairuz Rahman, Benjamin M. Marlin, Rebecca
+              Gorman
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Promises Made, Promises Kept: Safe Pareto Improvements via Ex Post Verifiable Commitments"
+            url: https://arxiv.org/abs/2505.00783
+            authors: Nathaniel Sauerberg, Caspar Oesterheld
+            year: 2025
+            venue: GAIW'25
+            kind: paper_preprint
+          - title: A Pragmatic View of AI Personhood
+            url: https://arxiv.org/abs/2510.26396
+          - title: Statutory Construction and Interpretation for Artificial Intelligence
+            url: https://arxiv.org/abs/2509.01186
+            authors: Luxi He, Nimra Nadeem, Michel Liao, Howard Chen, Danqi Chen, Mariano-Florentino Cuéllar, Peter Henderson
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Beyond Preferences in AI Alignment
+            url: https://arxiv.org/abs/2408.16984
+            authors: Tan Zhi-Xuan, Micah Carroll, Matija Franklin, Hal Ashton
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: Societal alignment frameworks can improve llm alignment
+            url: https://arxiv.org/abs/2503.00069
+      - id: aligning_multiple_game_theory
+        name: Theory for aligning multiple AIs
+        summary: >-
+          Use realistic game-theory variants (e.g. evolutionary game theory, computational game theory) to
+          describe/predict the collective and individual behaviours of AI agents in multi-agent scenarios.
+        theoryOfChange: >-
+          While traditional AGI safety focuses on idealized decision-theory and individual agents, it's plausible that
+          strategic AI agents will first emerge (or are emerging now) in a complex, multi-AI strategic landscape. We
+          need granular, realistic formal models of AIs' strategic interactions and collective dynamics to understand
+          this future.
+        seeAlso: a:aligning_multiple_tools, a:aligning_what
         orthodoxProblems:
           - "4"
-          - "7"
-          - "8"
-        targetCase: Mixed
+        broadApproaches:
+          - cognitive
         someNames:
           - lewis-hammond
           - emery-cooper
           - allan-chan
           - caspar-oesterheld
           - vincent-conitzer
+          - vojta-kovarik
         estimatedFTEs: "10"
-        fundedBy:
-          - google-deepmind
-        broadApproaches:
-          - cognitive
-        resources:
-          - title: Cooperative AI Foundation
-            url: https://www.cooperativeai.com/
-      - id: aligning-multiple-ais-tools-and-techniques
-        name: "Aligning multiple AIs: tools and techniques"
-        keywords:
-          - multi-agent
-          - agentic-systems
-          - game-theory
-          - benchmarks
-        lesswrongTags:
-          - multipolar-scenarios
         papers:
-          - title: Infrastructure for AI Agents
-            url: https://arxiv.org/abs/2501.10114
-          - title: "The Social Laboratory: A Psychometric Framework for Multi-Agent LLM Evaluation"
-            url: https://arxiv.org/abs/2510.01295
-          - title: A dataset of questions on decision-theoretic reasoning in Newcomb-like problems
-            url: https://arxiv.org/abs/2411.10588
-          - title: Reimagining Alignment
-            url: https://softmax.com/blog/reimagining-alignment
-          - title: "PGG-Bench: Contribute & Punish"
-            url: https://github.com/lechmazur/pgg_bench
-          - title: "Beyond the high score: Prosocial ability profiles of multi-agent populations"
-            url: https://arxiv.org/abs/2509.14485
-          - title: Multiplayer Nash Preference Optimization
-            url: https://arxiv.org/abs/2509.23102
-          - title: 2502.12203 - An Interpretable Automated Mechanism Design Framework with Large Language Models
-            url: https://arxiv.org/abs/2502.12203
-          - title: "AgentBreeder: Mitigating the AI Safety Risks of Multi-Agent Scaffolds via Self-Improvement"
-            url: https://arxiv.org/abs/2502.00757
-          - title: "When Autonomy Goes Rogue: Preparing for Risks of Multi-Agent Collusion in Social Systems"
-            url: https://arxiv.org/abs/2507.14660
-          - title: Virtual Agent Economies
-            url: http://arxiv.org/abs/2509.10147
-        summary: Develop tools and technique for designing and testing multi-agent AI scenarios, for auditing real-world muti-agent AI dynamics, and for aligning AIs in multi-AI settings
-        theoryOfChange: Addressing multi-agent AI dynamics is key for aligning near-future agents and their impact on the world. Feedback loops from multi-agent dynamics can radically change the future AI landscape, and require a different toolset from model psychology to audit and control
-        seeAlso: "Aligning multiple AIs: game theory , Aligning what"
+          - title: Multi-Agent Risks from Advanced AI
+            url: https://arxiv.org/abs/2502.14143
+            authors: >-
+              Lewis Hammond, Alan Chan, Jesse Clifton, Jason Hoelscher-Obermaier, Akbir Khan, Euan McLean, Chandler
+              Smith, Wolfram Barfuss, Jakob Foerster, Tomáš Gavenčiak, The Anh Han, Edward Hughes, Vojtěch Kovařík, Jan
+              Kulveit, Joel Z. Leibo, Caspar Oesterheld, Christian Schroeder de Witt, Nisarg Shah, Michael Wellman,
+              Paolo Bova, Theodor Cimpeanu, Carson Ezell, Quentin Feuillade-Montixi, Matija Franklin, Esben Kran, Igor
+              Krawczuk, Max Lamparth, Niklas Lauffer, Alexander Meinke, Sumeet Motwani, Anka Reuel, Vincent Conitzer,
+              Michael Dennis, Iason Gabriel, Adam Gleave, Gillian Hadfield, Nika Haghtalab, Atoosa Kasirzadeh, Sébastien
+              Krier, Kate Larson, Joel Lehman, David C. Parkes, Georgios Piliouras, Iyad Rahwan
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Higher-Order Belief in Incomplete Information MAIDs
+            url: https://arxiv.org/abs/2503.06323
+            authors: Jack Foxabbott, Rohan Subramani, Francis Rhys Ward
+            year: 2025
+            venue: 24th International Conference on Autonomous Agents and Multiagent Systems 2025
+            kind: paper_published
+          - title: AI Testing Should Account for Sophisticated Strategic Behaviour
+            url: https://arxiv.org/abs/2508.14927
+            authors: Vojtech Kovarik, Eric Olav Chen, Sami Petersen, Alexis Ghersengorin, Vincent Conitzer
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Characterising Simulation-Based Program Equilibria
+            url: https://arxiv.org/abs/2412.14570
+            authors: Emery Cooper, Caspar Oesterheld, Vincent Conitzer
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Strategic Intelligence in Large Language Models: Evidence from evolutionary Game Theory"
+            url: https://arxiv.org/abs/2507.02618
+            authors: Kenneth Payne, Baptiste Alloui-Cros
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Communication Enables Cooperation in LLM Agents: A Comparison with Curriculum-Based Approaches"
+            url: https://arxiv.org/abs/2510.05748
+            authors: Hachem Madmoun, Salem Lahlou
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Emergent social conventions and collective bias in LLM populations
+            url: https://www.science.org/doi/10.1126/sciadv.adu9368
+            authors: Ariel Flint Ashery, Luca Maria Aiello, Andrea Baronchelli
+            year: 2025
+            venue: Science Advances
+            kind: paper_published
+          - title: An Economy of AI Agents
+            url: https://arxiv.org/abs/2509.01063
+          - title: "Moloch's Bargain: Emergent Misalignment When LLMs Compete for Audiences"
+            url: https://arxiv.org/abs/2510.06105
+            authors: Batu El, James Zou
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+      - id: aligning_multiple_tools
+        name: Tools for aligning multiple AIs
+        summary: >-
+          Develop tools and technique for designing and testing multi-agent AI scenarios, for auditing real-world
+          multi-agent AI dynamics, and for aligning AIs in multi-AI settings.
+        theoryOfChange: >-
+          Addressing multi-agent AI dynamics is key for aligning near-future agents and their impact on the world.
+          Feedback loops from multi-agent dynamics can radically change the future AI landscape, and require a different
+          toolset from model psychology to audit and control.
+        seeAlso: a:aligning_multiple_game_theory, a:aligning_what
         orthodoxProblems:
           - "4"
-          - "7"
-          - "8"
-        targetCase: Mixed
         someNames:
           - lewis-hammond
           - emery-cooper
@@ -2786,44 +5368,84 @@ sections:
           - vincent-conitzer
           - gillian-hadfield
         estimatedFTEs: 10 - 15
-        fundedBy:
-          - open-philanthropy
-          - google-deepmind
-        broadApproaches:
-          - engineering
-          - behavioral
-      - id: aligned-to-who
-        name: Aligned to who
-        keywords:
-          - rlhf
-          - multi-agent
-          - value-specification
-        lesswrongTags:
-          - human-values
         papers:
-          - title: "2507.09650 - Cultivating Pluralism In Algorithmic Monoculture: The Community Alignment Dataset"
-            url: https://arxiv.org/abs/2507.09650
-          - title: 2503.05728 - Political Neutrality in AI Is Impossible - But Here Is How to Approximate It
-            url: https://arxiv.org/abs/2503.05728
-          - title: "The AI Power Disparity Index: Toward a Compound Measure of AI Actors' Power to Shape the AI Ecosystem"
-            url: https://ojs.aaai.org/index.php/AIES/article/view/36645
-          - title: “Societal and technological progress as sewing an ever-growing, ever-changing, patchy, and polychrome quilt”
-            url: https://arxiv.org/abs/2505.05197
-          - title: "“Democratic AI is Possible: The Democracy Levels Framework Shows How It Might Work”"
-            url: https://arxiv.org/abs/2411.09222
-          - title: Research Agenda for Sociotechnical Approaches to AI Safety
-            url: https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5097286
-          - title: Build Agent Advocates, Not Platform Agents
-            url: https://arxiv.org/abs/2505.04345
-          - title: Training LLM Agents to Empower Humans
-            url: https://arxiv.org/abs/2510.13709
-        summary: Develop ethical frameworks and technical protocols for taking the plurality of human values, cultures, and communities seriously when aligning AI to “humanity”
-        theoryOfChange: Principles of democracy, of pluralism, and of context-sensitivity should guide AI development, alignment, and deployment from the start, continuously shaping AI’s social and technical feedback loop on the road to AGI
-        seeAlso: Aligning what, Alignment to context
+          - title: Infrastructure for AI Agents
+            url: https://arxiv.org/abs/2501.10114
+            authors: >-
+              Alan Chan, Kevin Wei, Sihao Huang, Nitarshan Rajkumar, Elija Perrier, Seth Lazar, Gillian K. Hadfield,
+              Markus Anderljung
+            year: 2025
+            venue: arXiv (accepted to TMLR)
+            kind: paper_preprint
+          - title: "The Social Laboratory: A Psychometric Framework for Multi-Agent LLM Evaluation"
+            url: https://arxiv.org/abs/2510.01295
+            authors: Zarreen Reza
+            year: 2025
+            venue: NeurIPS 2025 Workshop on Evaluating the Evolving LLM Lifecycle
+            kind: paper_preprint
+          - title: A dataset of questions on decision-theoretic reasoning in Newcomb-like problems
+            url: https://arxiv.org/abs/2411.10588
+            authors: Caspar Oesterheld, Emery Cooper, Miles Kodama, Linh Chi Nguyen, Ethan Perez
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: Reimagining Alignment
+            url: https://softmax.com/blog/reimagining-alignment
+          - title: "PGG-Bench: Contribute & Punish"
+            url: https://github.com/lechmazur/pgg_bench
+            year: 2025
+            venue: GitHub
+            kind: code_tool
+          - title: "Beyond the high score: Prosocial ability profiles of multi-agent populations"
+            url: https://arxiv.org/abs/2509.14485
+          - title: Multiplayer Nash Preference Optimization
+            url: https://arxiv.org/abs/2509.23102
+            authors: >-
+              Fang Wu, Xu Huang, Weihao Xuan, Zhiwei Zhang, Yijia Xiao, Guancheng Wan, Xiaomin Li, Bing Hu, Peng Xia,
+              Jure Leskovec, Yejin Choi
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: An Interpretable Automated Mechanism Design Framework with Large Language Models
+            url: https://arxiv.org/abs/2502.12203
+            authors: Jiayuan Liu, Mingyu Guo, Vincent Conitzer
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "AgentBreeder: Mitigating the AI Safety Risks of Multi-Agent Scaffolds via Self-Improvement"
+            url: https://arxiv.org/abs/2502.00757
+            authors: J Rosser, Jakob Foerster
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "When Autonomy Goes Rogue: Preparing for Risks of Multi-Agent Collusion in Social Systems"
+            url: https://arxiv.org/abs/2507.14660
+            authors: Qibing Ren, Sitao Xie, Longxuan Wei, Zhenfei Yin, Junchi Yan, Lizhuang Ma, Jing Shao
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Virtual Agent Economies
+            url: http://arxiv.org/abs/2509.10147
+            authors: >-
+              Nenad Tomasev, Matija Franklin, Joel Z. Leibo, Julian Jacobs, William A. Cunningham, Iason Gabriel, Simon
+              Osindero
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+      - id: aligned_to_who
+        name: Aligned to who?
+        summary: >-
+          Develop ethical frameworks and technical protocols for taking the plurality of human values, cultures, and
+          communities seriously when aligning AI to "humanity"
+        theoryOfChange: >-
+          Principles of democracy, of pluralism, and of context-sensitivity should guide AI development, alignment, and
+          deployment from the start, continuously shaping AI's social and technical feedback loop on the road to AGI
+        seeAlso: a:aligning_what, a:alignment_to_context
         orthodoxProblems:
           - "1"
-          - "13"
-        targetCase: Optimistic
+        targetCase: average-case
+        broadApproaches:
+          - behavioral
         someNames:
           - joel-z-leibo
           - divya-siddarth
@@ -2833,55 +5455,1584 @@ sections:
           - ai-objectives-institute
           - the-collective-intelligence-project
         estimatedFTEs: 5 - 15
-        fundedBy:
-          - future-of-life-institute
-          - survival-flourishing-fund
-          - google-deepmind
-        broadApproaches:
-          - behavioral
-      - id: aligning-what
-        name: Aligning what
-        keywords:
-          - value-specification
-          - agentic-systems
-          - multi-agent
         papers:
-          - title: Towards a Scale-Free Theory of Intelligent Agency
-            url: https://www.alignmentforum.org/posts/5tYTKX4pNpiG4vzYg/towards-a-scale-free-theory-of-intelligent-agency
-          - title: Alignment first, intelligence later
-            url: https://chrislakin.blog/p/alignment-first-intelligence-later
-          - title: "Emmett Shear on Building AI That Actually Cares: Beyond Control and Steering"
-            url: https://a16z.simplecast.com/episodes/emmett-shear-on-building-ai-that-actually-cares-beyond-control-and-steering-TRwfxH0r
-          - title: End A Subset Of Conversations
-            url: https://www.anthropic.com/research/end-subset-conversations
-          - title: Full-Stack Alignment
-            url: https://www.full-stack-alignment.ai
-          - title: On Eudaimonia and Optimization
-            url: https://docs.google.com/document/d/1cKbqYSGspfJavXvnhsp3mAuxHh08rNbP7tzYieqLiXw/edit?tab=t.0
-          - title: AI Governance through Markets
-            url: https://arxiv.org/abs/2501.17755
-          - title: Collective cooperative intelligence
-            url: https://www.pnas.org/doi/abs/10.1073/pnas.2319948121
-        summary: Develop alternatives to AI-agent-level models of alignment, treating human-AI interactions, AI-assisted institutions, AI-inclusive economic or cultural systems, sub-individual AI drives, and other reality-shaping processes as subject to alignment
-        theoryOfChange: Modelling multiple reality-shaping processes above and below the level of the individual AI, some of which are themselves quasi-agential (e.g. cultures) or intelligence-like (e.g. markets), will develop AI alignment into a mature science for managing the transition to an AGI civilization
-        seeAlso: "Aligning multiple AIs: game theory, Alignment to context, Aligned to who"
+          - title: "Cultivating Pluralism In Algorithmic Monoculture: The Community Alignment Dataset"
+            url: https://arxiv.org/abs/2507.09650
+            authors: >-
+              Lily Hong Zhang, Smitha Milli, Karen Jusko, Jonathan Smith, Brandon Amos, Wassim Bouaziz, Manon Revel,
+              Jack Kussman, Yasha Sheynin, Lisa Titus, Bhaktipriya Radharapu, Jane Yu, Vidya Sarma, Kris Rose,
+              Maximilian Nickel
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Political Neutrality in AI Is Impossible- But Here Is How to Approximate It
+            url: https://arxiv.org/abs/2503.05728
+            authors: >-
+              Jillian Fisher, Ruth E. Appel, Chan Young Park, Yujin Potter, Liwei Jiang, Taylor Sorensen, Shangbin Feng,
+              Yulia Tsvetkov, Margaret E. Roberts, Jennifer Pan, Dawn Song, Yejin Choi
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "The AI Power Disparity Index: Toward a Compound Measure of AI Actors' Power to Shape the AI Ecosystem"
+            url: https://ojs.aaai.org/index.php/AIES/article/view/36645
+          - title: Societal and technological progress as sewing an ever-growing, ever-changing, patchy, and polychrome quilt
+            url: https://arxiv.org/abs/2505.05197
+            authors: >-
+              Joel Z. Leibo, Alexander Sasha Vezhnevets, William A. Cunningham, Sébastien Krier, Manfred Diaz, Simon
+              Osindero
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Democratic AI is Possible. The Democracy Levels Framework Shows How It Might Work
+            url: https://arxiv.org/abs/2411.09222
+            authors: >-
+              Aviv Ovadya, Kyle Redman, Luke Thorburn, Quan Ze Chen, Oliver Smith, Flynn Devine, Andrew Konya, Smitha
+              Milli, Manon Revel, K. J. Kevin Feng, Amy X. Zhang, Bilva Chandra, Michiel A. Bakker, Atoosa Kasirzadeh
+            year: 2024
+            venue: arXiv (Accepted to ICML 2025 Position Paper Track)
+            kind: paper_preprint
+          - title: Research Agenda for Sociotechnical Approaches to AI Safety
+            url: https://papers.ssrn.com/sol3/papers.cfm?abstract_id=5097286
+          - title: Build Agent Advocates, Not Platform Agents
+            url: https://arxiv.org/abs/2505.04345
+            authors: Sayash Kapoor, Noam Kolt, Seth Lazar
+            year: 2025
+            venue: arXiv (accepted to ICML 2025 position paper track)
+            kind: paper_preprint
+          - title: Training LLM Agents to Empower Humans
+            url: https://arxiv.org/abs/2510.13709
+            authors: Evan Ellis, Vivek Myers, Jens Tuyls, Sergey Levine, Anca Dragan, Benjamin Eysenbach
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+      - id: aligning_what
+        name: Aligning what?
+        summary: >-
+          Develop alternatives to agent-level models of alignment, by treating human-AI interactions, AI-assisted
+          institutions, AI economic or cultural systems, drives within one AI, and other causal/constitutive processes
+          as subject to alignment
+        theoryOfChange: >-
+          Model multiple reality-shaping processes above and below the level of the individual AI, some of which are
+          themselves quasi-agential (e.g. cultures) or intelligence-like (e.g. markets), will develop AI alignment into
+          a mature science for managing the transition to an AGI civilization
+        seeAlso: a:aligning_multiple_game_theory, a:alignment_to_context, a:aligned_to_who
         orthodoxProblems:
           - "1"
-          - "2"
           - "4"
           - "5"
-          - "13"
-        targetCase: Mixed
         someNames:
           - richard-ngo
           - emmett-shear
           - softmax
           - full-stack-alignment
           - ai-objectives-institute
-        estimatedFTEs: 5 -10
-        fundedBy:
-          - future-of-life-institute
-          - emmet-shear
+          - sahil
+          - tj
+          - andrew-critch
+        estimatedFTEs: 5-10
+        papers:
+          - title: Towards a scale-free theory of intelligent agency
+            url: https://www.alignmentforum.org/posts/5tYTKX4pNpiG4vzYg/towards-a-scale-free-theory-of-intelligent-agency
+            authors: Richard Ngo
+            year: 2025
+            venue: AI Alignment Forum
+            kind: lesswrong
+          - title: Alignment first, intelligence later
+            url: https://chrislakin.blog/p/alignment-first-intelligence-later
+          - title: "Emmett Shear on Building AI That Actually Cares: Beyond Control and Steering"
+            url: >-
+              https://a16z.simplecast.com/episodes/emmett-shear-on-building-ai-that-actually-cares-beyond-control-and-steering-TRwfxH0r
+            authors: Emmett Shear, Erik Torenberg, Séb Krier
+            year: 2025
+            venue: a16z Podcast
+            kind: podcast
+          - title: End A Subset Of Conversations
+            url: https://www.anthropic.com/research/end-subset-conversations
+          - title: "Full-Stack Alignment: Co-Aligning AI and Institutions with Thick Models of Value"
+            url: https://www.full-stack-alignment.ai
+            kind: personal_page
+          - title: On Eudaimonia and Optimization
+            url: https://docs.google.com/document/d/1cKbqYSGspfJavXvnhsp3mAuxHh08rNbP7tzYieqLiXw/edit?tab=t.0%20
+            venue: Google Docs
+            kind: error_detected
+          - title: AI Governance through Markets
+            url: https://arxiv.org/abs/2501.17755
+          - title: Collective cooperative intelligence
+            url: https://www.pnas.org/doi/abs/10.1073/pnas.2319948121
+          - title: Multipolar AI is Underrated
+            url: https://www.lesswrong.com/posts/JjYu75q3hEMBgtvr8/multipolar-ai-is-underrated
+          - title: Unknown - Content Unavailable (429 Error)
+            url: https://www.lesswrong.com/posts/tQ9vWm4b57HFqbaRj/what-if-not-agency
+            venue: LessWrong
+            kind: error_detected
+          - title: https://substack.com/home/post/p-171042125
+            url: https://substack.com/home/post/p-171042125
+          - title: The Multiplicity Thesis, Collective Intelligence, and Morality
+            url: https://themultiplicity.ai/blog/thesis
+  - id: evals
+    name: Evals
+    agendas:
+      - id: agi_metrics
+        name: AGI metrics
+        summary: Evals with the explicit aim of measuring progress towards full human-level generality.
+        theoryOfChange: Help predict timelines for risk awareness and strategy.
+        seeAlso: a:evals_capability
         broadApproaches:
           - behavioral
-          - cognitive
+        someNames:
+          - cais
+          - cfi-kinds-of-intelligence
+          - apart-research
+          - openai
+          - metr
+          - lexin-zhou
+          - adam-scholl
+          - lorenzo-pacchiardi
+        estimatedFTEs: 10-50
+        critiques:
+          - >-
+            [Is the Definition of AGI a
+            Percentage?](https://aievaluation.substack.com/p/is-the-definition-of-agi-a-percentage), [The "Length" of
+            "Horizons"](https://www.lesswrong.com/posts/PzLSuaT6WGLQGJJJD/the-length-of-horizons)
+        papers:
+          - title: "GDPval: Evaluating AI Model Performance on Real-World Economically Valuable Tasks"
+            url: https://arxiv.org/abs/2510.04374
+            authors: >-
+              Tejal Patwardhan, Rachel Dias, Elizabeth Proehl, Grace Kim, Michele Wang, Olivia Watkins, Simón Posada
+              Fishman, Marwan Aljubeh, Phoebe Thacker, Laurance Fauconnet, Natalie S. Kim, Patrick Chao, Samuel
+              Miserendino, Gildas Chabot, David Li, Michael Sharman, Alexandra Barr, Amelia Glaese, Jerry Tworek
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "HCAST: Human-Calibrated Autonomy Software Tasks"
+            url: https://arxiv.org/abs/2503.17354
+          - title: A Definition of AGI
+            url: https://arxiv.org/pdf/2510.18212
+            authors: >-
+              Dan Hendrycks, Dawn Song, Christian Szegedy, Honglak Lee, Yarin Gal, Erik Brynjolfsson, Sharon Li, Andy
+              Zou, Lionel Levine, Bo Han, Jie Fu, Ziwei Liu, Jinwoo Shin, Kimin Lee, Mantas Mazeika, Long Phan, George
+              Ingebretsen, Adam Khoja, Cihang Xie, Olawale Salaudeen, Matthias Hein, Kevin Zhao, Alexander Pan, David
+              Duvenaud, Bo Li, Steve Omohundro, Gabriel Alfour, Max Tegmark, Kevin McGrew, Gary Marcus, Jaan Tallinn,
+              Eric Schmidt, Yoshua Bengio
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Remote Labor Index
+            url: https://scale.com/leaderboard/rli
+          - title: "ADeLe v1.0: A battery for AI Evaluation with explanatory and predictive power"
+            url: https://kinds-of-intelligence-cfi.github.io/ADELE/
+            authors: >-
+              Lexin Zhou, Lorenzo Pacchiardi, Fernando Martínez-Plumed, Katherine M. Collins, Yael Moros-Daval,
+              Seraphina Zhang, Qinlin Zhao, Yitian Huang, Luning Sun, Jonathan E. Prunty, Zongqian Li, Pablo
+              Sánchez-García, Kexin Jiang Chen, Pablo A. M. Casares, Jiyun Zu, John Burden, Behzad Mehrbakhsh, David
+              Stillwell, Manuel Cebrian, Jindong Wang, Peter Henderson, Sherry Tongshuang Wu, Patrick C. Kyllonen, Lucy
+              Cheke, Xing Xie, José Hernández-Orallo
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+      - id: evals_capability
+        name: Capability evals
+        summary: >-
+          Make tools that can actually check whether a model has a certain capability or propensity. We default to low-n
+          sampling of a vast latent space but aim to do better.
+        theoryOfChange: >-
+          Keep a close eye on what capabilities are acquired when, so that frontier labs and regulators are better
+          informed on what security measures are already necessary (and hopefully they extrapolate). You can't regulate
+          without them.
+        seeAlso: >-
+          [Deepmind's frontier safety
+          framework](https://deepmind.google/blog/strengthening-our-frontier-safety-framework/),
+          [Aether](https://www.lesswrong.com/posts/B8Cmtf5gdHwxb8qtT/aether-july-2025-update)
+        targetCase: average-case
+        broadApproaches:
+          - behavioral
+        someNames:
+          - metr
+          - aisi
+          - apollo-research
+          - marrius-hobbhahn
+          - meg-tong
+          - mary-phuong
+          - beth-barnes
+          - thomas-kwa
+          - joel-becker
+        estimatedFTEs: 100+
+        critiques:
+          - >-
+            [Large Language Models Often Know When They Are Being Evaluated](https://arxiv.org/abs/2505.23836), [AI
+            Sandbagging: Language Models can Strategically Underperform on
+            Evaluations](https://arxiv.org/abs/2406.07358), [The Leaderboard
+            Illusion](https://arxiv.org/abs/2504.20879), [Do Large Language Model Benchmarks Test
+            Reliability?](https://arxiv.org/abs/2502.03461)
+        papers:
+          - title: Forecasting Rare Language Model Behaviors
+            url: https://arxiv.org/abs/2502.16797
+            authors: >-
+              Erik Jones, Meg Tong, Jesse Mu, Mohammed Mahfoud, Jan Leike, Roger Grosse, Jared Kaplan, William Fithian,
+              Ethan Perez, Mrinank Sharma
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Model Tampering Attacks Enable More Rigorous Evaluations of LLM Capabilities
+            url: https://arxiv.org/abs/2502.05209
+            authors: >-
+              Zora Che, Stephen Casper, Robert Kirk, Anirudh Satheesh, Stewart Slocum, Lev E McKinney, Rohit Gandikota,
+              Aidan Ewart, Domenic Rosati, Zichu Wu, Zikui Cai, Bilal Chughtai, Yarin Gal, Furong Huang, Dylan
+              Hadfield-Menell
+            year: 2025
+            venue: arXiv (accepted to TMLR)
+            kind: paper_preprint
+          - title: "The Elicitation Game: Evaluating Capability Elicitation Techniques"
+            url: https://arxiv.org/abs/2502.02180
+            authors: Felix Hofstätter, Teun van der Weij, Jayden Teoh, Rada Djoneva, Henning Bartsch, Francis Rhys Ward
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: A Toy Evaluation of Inference Code Tampering
+            url: https://alignment.anthropic.com/2024/rogue-eval/index.html
+            year: 2024
+            venue: Anthropic Alignment Science Blog
+            kind: blog_post
+          - title: Automated Capability Discovery via Foundation Model Self-Exploration
+            url: https://arxiv.org/abs/2502.07577
+            authors: Cong Lu, Shengran Hu, Jeff Clune
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Measuring the Impact of Early-2025 AI on Experienced Open-Source Developer Productivity
+            url: https://metr.org/blog/2025-07-10-early-2025-ai-experienced-os-dev-study/
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "When Ethics and Payoffs Diverge: LLM Agents in Morally Charged Social Dilemmas"
+            url: https://arxiv.org/abs/2505.19212
+            authors: Steffen Backmann, David Guzman Piedrahita, Emanuel Tewolde, Rada Mihalcea, Bernhard Schölkopf, Zhijing Jin
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "AILuminate: Introducing v1.0 of the AI Risk and Reliability Benchmark from MLCommons"
+            url: https://arxiv.org/abs/2503.05731
+            authors: >-
+              Shaona Ghosh, Heather Frase, Adina Williams, Sarah Luger, Paul Röttger, Fazl Barez, Sean McGregor, Kenneth
+              Fricklas, Mala Kumar, Quentin Feuillade-Montixi, Kurt Bollacker, Felix Friedrich, Ryan Tsang, Bertie
+              Vidgen, Alicia Parrish, Chris Knotz, Eleonora Presani, Jonathan Bennion, Marisa Ferrara Boston, Mike
+              Kuniavsky, Wiebke Hutiri, James Ezick, Malek Ben Salem, Rajat Sahay, Sujata Goswami, Usman Gohar, Ben
+              Huang, Supheakmungkol Sarin, Elie Alhajjar, Canyu Chen, Roman Eng, Kashyap Ramanandula Manjusha, Virendra
+              Mehta, Eileen Long, Murali Emani, Natan Vidra, Benjamin Rukundo, Abolfazl Shahbazi, Kongtao Chen, Rajat
+              Ghosh, Vithursan Thangarasa, Pierre Peigné, Abhinav Singh, Max Bartolo, Satyapriya Krishna, Mubashara
+              Akhtar, Rafael Gold, Cody Coleman, Luis Oala, Vassil Tashev, Joseph Marvin Imperial, Amy Russ, Sasidhar
+              Kunapuli, Nicolas Miailhe, Julien Delaunay, Bhaktipriya Radharapu, Rajat Shinde, Tuesday, Debojyoti Dutta,
+              Declan Grabb, Ananya Gangavarapu, Saurav Sahay, Agasthya Gangavarapu, Patrick Schramowski, Stephen Singam,
+              Tom David, Xudong Han, Priyanka Mary Mammen, Tarunima Prabhakar, Venelin Kovatchev, Rebecca Weiss, Ahmed
+              Ahmed, Kelvin N. Manyeki, Sandeep Madireddy, Foutse Khomh, Fedor Zhdanov, Joachim Baumann, Nina Vasan,
+              Xianjun Yang, Carlos Mougn, Jibin Rajan Varghese, Hussain Chinoy, Seshakrishna Jitendar, Manil Maskey,
+              Claire V. Hardgrove, Tianhao Li, Aakash Gupta, Emil Joswin, Yifan Mai, Shachi H Kumar, Cigdem Patlak,
+              Kevin Lu, Vincent Alessi, Sree Bhargavi Balija, Chenhe Gu, Robert Sullivan, James Gealy, Matt Lavrisa,
+              James Goel, Peter Mattson, Percy Liang, Joaquin Vanschoren
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Petri: An open-source auditing tool to accelerate AI safety research"
+            url: https://www.anthropic.com/research/petri-open-source-auditing
+            authors: >-
+              Kai Fronsdal, Isha Gupta, Abhay Sheshadri, Jonathan Michala, Stephen McAleer, Rowan Wang, Sara Price,
+              Samuel R. Bowman
+            year: 2025
+            venue: Anthropic Blog
+            kind: blog_post
+          - title: "Research Note: Our scheming precursor evals had limited predictive power for our in-context scheming evals"
+            url: >-
+              https://www.apolloresearch.ai/blog/research-note-our-scheming-precursor-evals-had-limited-predictive-power-for-our-in-context-scheming-evals
+            authors: Marius Hobbhahn
+            year: 2025
+            venue: Apollo Research Blog
+            kind: blog_post
+          - title: Adversarial ML Problems Are Getting Harder to Solve and to Evaluate
+            url: https://arxiv.org/abs/2502.02260
+            authors: Javier Rando, Jie Zhang, Nicholas Carlini, Florian Tramèr
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Among AIs
+            url: https://www.4wallai.com/amongais
+            year: 2025
+            venue: 4Wall AI website
+            kind: blog_post
+          - title: "Safety by Measurement: A Systematic Literature Review of AI Safety Evaluation Methods"
+            url: https://arxiv.org/abs/2505.05541
+            authors: Markov Grey, Charbel-Raphaël Segerie
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: >-
+              Correlating and Predicting Human Evaluations of Language Models from Natural Language Processing
+              Benchmarks
+            url: https://arxiv.org/abs/2502.18339
+            authors: >-
+              Rylan Schaeffer, Punit Singh Koura, Binh Tang, Ranjan Subramanian, Aaditya K Singh, Todor Mihaylov,
+              Prajjwal Bhargava, Lovish Madaan, Niladri S. Chatterji, Vedanuj Goswami, Sergey Edunov, Dieuwke Hupkes,
+              Sanmi Koyejo, Sharan Narang
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "The FACTS Grounding Leaderboard: Benchmarking LLMs' Ability to Ground Responses to Long-Form Input"
+            url: https://arxiv.org/abs/2501.03200
+            authors: >-
+              Alon Jacovi, Andrew Wang, Chris Alberti, Connie Tao, Jon Lipovetz, Kate Olszewska, Lukas Haas, Michelle
+              Liu, Nate Keating, Adam Bloniarz, Carl Saroufim, Corey Fry, Dror Marcus, Doron Kukliansky, Gaurav Singh
+              Tomar, James Swirhun, Jinwei Xing, Lily Wang, Madhu Gurumurthy, Michael Aaron, Moran Ambar, Rachana
+              Fellinger, Rui Wang, Zizhao Zhang, Sasha Goldshtein, Dipanjan Das
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Evaluating Language Model Reasoning about Confidential Information
+            url: https://arxiv.org/abs/2508.19980
+            authors: Dylan Sam, Alexander Robey, Andy Zou, Matt Fredrikson, J. Zico Kolter
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Evaluating the Goal-Directedness of Large Language Models
+            url: https://arxiv.org/abs/2504.11844
+            authors: >-
+              Tom Everitt, Cristina Garbacea, Alexis Bellot, Jonathan Richens, Henry Papadatos, Siméon Campos, Rohin
+              Shah
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Generative Value Conflicts Reveal LLM Priorities
+            url: https://arxiv.org/abs/2509.25369
+            authors: Andy Liu, Kshitish Ghate, Mona Diab, Daniel Fried, Atoosa Kasirzadeh, Max Kleiman-Weiner
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Technical Report: Evaluating Goal Drift in Language Model Agents"
+            url: https://arxiv.org/abs/2505.02709
+            authors: Rauno Arike, Elizabeth Donoway, Henning Bartsch, Marius Hobbhahn
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "MALT: A Dataset of Natural and Prompted Behaviors That Threaten Eval Integrity"
+            url: https://metr.org/blog/2025-10-14-malt-dataset-of-natural-and-prompted-behaviors/
+            authors: Neev Parikh, Hjalmar Wijk
+            year: 2025
+            venue: METR Blog
+            kind: blog_post
+          - title: Predicting the Performance of Black-box LLMs through Self-Queries
+            url: https://arxiv.org/abs/2501.01558
+            authors: Dylan Sam, Marc Finzi, J. Zico Kolter
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Infini-gram mini: Exact n-gram Search at the Internet Scale with FM-Index"
+            url: https://arxiv.org/abs/2506.12229
+            authors: Hao Xu, Jiacheng Liu, Yejin Choi, Noah A. Smith, Hannaneh Hajishirzi
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Hyperbolic model fits METR capabilities estimate worse than exponential model
+            url: https://lesswrong.com/posts/ZEuDH2W3XdRaTwpjD/hyperbolic-model-fits-metr-capabilities-estimate-worse-than
+            authors: gjm
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: New website analyzing AI companies' model evals
+            url: https://lesswrong.com/posts/nmaKpoHxmzjT8yXTk/new-website-analyzing-ai-companies-model-evals
+            authors: Zach Stein-Perlman
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: "Research Note: Our scheming precursor evals had limited predictive power for our in-context scheming evals"
+            url: https://lesswrong.com/posts/9tqpPP4FwSnv9AWsi/research-note-our-scheming-precursor-evals-had-limited
+            authors: Marius Hobbhahn
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: How Fast Can Algorithms Advance Capabilities? | Epoch Gradient Update
+            url: https://lesswrong.com/posts/qhjNejRxbMGQp4wHt/how-fast-can-algorithms-advance-capabilities-or-epoch
+            authors: Henry Josephson, Spencer Guo, Teddy Foley, Jack Sanderson, Anqi Qu
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: "Safety by Measurement: A Systematic Literature Review of AI Safety Evaluation Methods"
+            url: https://lesswrong.com/posts/CwdCYmsutwXwnYtEF/paper-safety-by-measurement-a-systematic-literature-review
+            authors: markov, Charbel-Raphaël
+            year: 2025
+            venue: arXiv
+            kind: lesswrong
+          - title: We should try to automate AI safety work asap
+            url: https://lesswrong.com/posts/W3KfxjbqBAnifBQoi/we-should-try-to-automate-ai-safety-work-asap
+            authors: Marius Hobbhahn
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: Validating against a misalignment detector is very different to training against one
+            url: https://lesswrong.com/posts/CXYf7kGBecZMajrXC/validating-against-a-misalignment-detector-is-very-different
+            authors: mattmacdermott
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: Why do misalignment risks increase as AIs get more capable?
+            url: https://lesswrong.com/posts/NDotm7oLHfR56g4sD/why-do-misalignment-risks-increase-as-ais-get-more-capable
+            authors: Ryan Greenblatt
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: Open Philanthropy Technical AI Safety RFP - $40M Available Across 21 Research Areas
+            url: https://lesswrong.com/posts/wbJxRNxuezvsGFEWv/open-philanthropy-technical-ai-safety-rfp-usd40m-available
+            authors: jake_mendel, maxnadeau, Peter Favaloro
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: Why Future AIs will Require New Alignment Methods
+            url: https://lesswrong.com/posts/TxiB6hvnQqxXB5XDJ/why-future-ais-will-require-new-alignment-methods
+            authors: Alvin Ånestrand
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: 100+ concrete projects and open problems in evals
+            url: https://lesswrong.com/posts/LhnqegFoykcjaXCYH/100-concrete-projects-and-open-problems-in-evals
+            authors: Marius Hobbhahn
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: AI companies should be safety-testing the most capable versions of their models
+            url: https://lesswrong.com/posts/tQzeafo9HjCeXn7ZF/ai-companies-should-be-safety-testing-the-most-capable
+            authors: Steven Adler
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+      - id: evals_autonomy
+        name: Autonomy evals
+        summary: Measure an AI's ability to act autonomously to complete long-horizon, complex tasks.
+        theoryOfChange: >-
+          By measuring how long and complex a task an AI can complete (its "time horizon"), we can track capability
+          growth and identify when models gain dangerous autonomous capabilities (like R&D acceleration or replication).
+        seeAlso: >-
+          a:evals_capability, [OpenAI Preparedness](https://openai.com/index/updating-our-preparedness-framework/),
+          [Anthropic RSP](https://www.anthropic.com/rsp-updates)
+        targetCase: average-case
+        broadApproaches:
+          - behavioral
+        someNames:
+          - metr
+          - thomas-kwa
+          - ben-west
+          - joel-becker
+          - beth-barnes
+          - hjalmar-wijk
+          - tao-lin
+          - giulio-starace
+          - oliver-jaffe
+          - dane-sherburn
+          - sanidhya-vijayvargiya
+          - aditya-bharat-soni
+          - xuhui-zhou
+        estimatedFTEs: 10-50
+        critiques:
+          - >-
+            [Measuring the Impact of Early-2025 AI on Experienced Open-Source Developer
+            Productivity.](https://metr.org/blog/2025-07-10-early-2025-ai-experienced-os-dev-study/) [The "Length" of
+            "Horizons"](https://www.lesswrong.com/posts/PzLSuaT6WGLQGJJJD/the-length-of-horizons)
+        papers:
+          - title: Measuring AI Ability to Complete Long Tasks
+            url: https://metr.org/blog/2025-03-19-measuring-ai-ability-to-complete-long-tasks/
+            authors: >-
+              Thomas Kwa, Ben West, Joel Becker, Amy Deng, Katharyn Garcia, Max Hasin, Sami Jawhar, Megan Kinniment,
+              Nate Rush, Sydney Von Arx, Ryan Bloom, Thomas Broadley, Haoxing Du, Brian Goodrich, Nikola Jurkovic, Luke
+              Harold Miles, Seraphina Nix, Tao Lin, Neev Parikh, David Rein, Lucas Jun Koba Sato, Hjalmar Wijk, Daniel
+              M. Ziegler, Elizabeth Barnes, Lawrence Chan
+            year: 2025
+            venue: METR Blog
+            kind: blog_post
+          - title: Details about METR's evaluation of OpenAI GPT-5
+            url: https://metr.github.io/autonomy-evals-guide/gpt-5-report/
+            year: 2025
+            venue: METR's Autonomy Evaluation Resources
+            kind: blog_post
+          - title: "RE-Bench: Evaluating frontier AI R&D capabilities of language model agents against human experts"
+            url: https://arxiv.org/abs/2411.15114
+            authors: >-
+              Hjalmar Wijk, Tao Lin, Joel Becker, Sami Jawhar, Neev Parikh, Thomas Broadley, Lawrence Chan, Michael
+              Chen, Josh Clymer, Jai Dhyani, Elena Ericheva, Katharyn Garcia, Brian Goodrich, Nikola Jurkovic, Holden
+              Karnofsky, Megan Kinniment, Aron Lajko, Seraphina Nix, Lucas Sato, William Saunders, Maksym Taran, Ben
+              West, Elizabeth Barnes
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: "GSM-Agent: Understanding Agentic Reasoning Using Controllable Environments"
+            url: https://arxiv.org/abs/2509.21998
+            authors: Hanlin Zhu, Tianyu Guo, Song Mei, Stuart Russell, Nikhil Ghosh, Alberto Bietti, Jiantao Jiao
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "OpenAgentSafety: A Comprehensive Framework for Evaluating Real-World AI Agent Safety"
+            url: https://t.co/XfspwlzYdl
+            authors: >-
+              Sanidhya Vijayvargiya, Aditya Bharat Soni, Xuhui Zhou, Zora Zhiruo Wang, Nouha Dziri, Graham Neubig,
+              Maarten Sap
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Details about METR's preliminary evaluation of OpenAI's o3 and o4-mini
+            url: https://metr.github.io/autonomy-evals-guide/openai-o3-report/
+            authors: METR
+            year: 2025
+            venue: METR Website
+            kind: blog_post
+          - title: "PaperBench: Evaluating AI's Ability to Replicate AI Research"
+            url: https://t.co/dHN2N0tUhC
+            authors: >-
+              Giulio Starace, Oliver Jaffe, Dane Sherburn, James Aung, Chan Jun Shern, Leon Maksin, Rachel Dias, Evan
+              Mays, Benjamin Kinsella, Wyatt Thompson, Johannes Heidecke, Mia Glaese, Tejal Patwardhan
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: How Does Time Horizon Vary Across Domains?
+            url: https://metr.org/blog/2025-07-14-how-does-time-horizon-vary-across-domains/
+            year: 2025
+            venue: METR Blog
+            kind: blog_post
+          - title: "Vending-Bench: A Benchmark for Long-Term Coherence of Autonomous Agents"
+            url: https://arxiv.org/abs/2502.15840
+            authors: Axel Backlund, Lukas Petersson
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Forecasting Frontier Language Model Agent Capabilities
+            url: https://arxiv.org/abs/2502.15850
+            authors: Govind Pimpale, Axel Højmark, Jérémy Scheurer, Marius Hobbhahn
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Project Vend: Can Claude run a small shop? (And why does that matter?)"
+            url: https://www.anthropic.com/research/project-vend-1
+            year: 2025
+            venue: Anthropic Website
+            kind: blog_post
+          - title: "OS-Harm: A Benchmark for Measuring Safety of Computer Use Agents"
+            url: https://arxiv.org/abs/2506.14866
+            authors: >-
+              Thomas Kuntz, Agatha Duzan, Hao Zhao, Francesco Croce, Zico Kolter, Nicolas Flammarion, Maksym
+              Andriushchenko
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Fulcrum
+            url: https://fulcrumresearch.ai/2025/10/22/introducing-orchestra-quibbler.html
+      - id: evals_wmd
+        name: WMD evals (Weapons of Mass Destruction)
+        summary: >-
+          Evaluate whether AI models possess dangerous knowledge or capabilities related to biological and chemical
+          weapons, such as biosecurity or chemical synthesis.
+        theoryOfChange: >-
+          By benchmarking and tracking AI's knowledge of biology and chemistry, we can identify when models become
+          capable of accelerating WMD development or misuse, allowing for timely intervention.
+        seeAlso: a:evals_capability, a:evals_autonomy, a:various_redteams
+        targetCase: pessimistic
+        broadApproaches:
+          - behavioral
+        someNames:
+          - lennart-justen
+          - haochen-zhao
+          - xiangru-tang
+          - ziran-yang
+          - aidan-peppin
+          - anka-reuel
+          - stephen-casper
+        estimatedFTEs: 10-50
+        critiques:
+          - "[The Reality of AI and Biorisk](https://arxiv.org/abs/2412.01946)"
+        papers:
+          - title: "Virology Capabilities Test (VCT): A Multimodal Virology Q&A Benchmark"
+            url: https://arxiv.org/abs/2504.16137
+          - title: LLMs Outperform Experts on Challenging Biology Benchmarks
+            url: https://arxiv.org/abs/2505.06108
+            authors: Lennart Justen
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "ChemSafetyBench: Benchmarking LLM Safety on Chemistry Domain"
+            url: https://arxiv.org/abs/2411.16736
+            authors: >-
+              Haochen Zhao, Xiangru Tang, Ziran Yang, Xiao Han, Xuanzhi Feng, Yueqing Fan, Senhao Cheng, Di Jin, Yilun
+              Zhao, Arman Cohan, Mark Gerstein
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: The Reality of AI and Biorisk
+            url: https://arxiv.org/abs/2412.01946
+            authors: >-
+              Aidan Peppin, Anka Reuel, Stephen Casper, Elliot Jones, Andrew Strait, Usman Anwar, Anurag Agrawal, Sayash
+              Kapoor, Sanmi Koyejo, Marie Pellat, Rishi Bommasani, Nick Frosst, Sara Hooker
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: "The Safety Gap Toolkit: Evaluating Hidden Dangers of Open-Source Models"
+            url: https://arxiv.org/abs/2507.11544
+            authors: Ann-Kathrin Dombrowski, Dillon Bowen, Adam Gleave, Chris Cundy
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Best Practices for Biorisk Evaluations on Open-Weight Bio-Foundation Models
+            url: https://arxiv.org/abs/2510.27629
+            authors: >-
+              Boyi Wei, Zora Che, Nathaniel Li, Udari Madhushani Sehwag, Jasper Götting, Samira Nedungadi, Julian
+              Michael, Summer Yue, Dan Hendrycks, Peter Henderson, Zifan Wang, Seth Donoughe, Mantas Mazeika
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+      - id: evals_situational_awareness
+        name: Situational awareness and self-awareness evals
+        summary: >-
+          Evaluate if models understand their own internal states and behaviors, their environment, and whether they are
+          in a test or real-world deployment.
+        theoryOfChange: >-
+          if an AI can distinguish between evaluation and deployment ("evaluation awareness"), it might hide dangerous
+          capabilities (scheming/sandbagging). By measuring self- and situational-awareness, we can better assess this
+          risk and build more robust evaluations.
+        seeAlso: a:evals_sandbagging, a:various_redteams, sec:model_psychology
+        targetCase: worst-case
+        broadApproaches:
+          - behavioral
+        someNames:
+          - jan-betley
+          - xuchan-bao
+          - martn-soto
+          - mary-phuong
+          - roland-s-zimmermann
+          - joe-needham
+          - giles-edkins
+          - govind-pimpale
+          - kai-fronsdal
+          - david-lindner
+          - lang-xiong
+          - xiaoyan-bai
+        estimatedFTEs: 30-70
+        critiques:
+          - >-
+            [Lessons from a Chimp: AI "Scheming" and the Quest for Ape Language](https://arxiv.org/abs/2507.03409),
+            [It's hard to make scheming evals look realistic for
+            LLMs](https://www.lesswrong.com/posts/TBk2dbWkg2F7dB3jb/it-s-hard-to-make-scheming-evals-look-realistic-for-llms)
+        papers:
+          - title: "Tell me about yourself: LLMs are aware of their learned behaviors"
+            url: https://arxiv.org/abs/2501.11120
+            authors: Jan Betley, Xuchan Bao, Martín Soto, Anna Sztyber-Betley, James Chua, Owain Evans
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Future Events as Backdoor Triggers: Investigating Temporal Vulnerabilities in LLMs"
+            url: https://arxiv.org/pdf/2407.04108
+            authors: Sara Price, Arjun Panickssery, Sam Bowman, Asa Cooper Stickland
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: Evaluating Frontier Models for Stealth and Situational Awareness
+            url: https://arxiv.org/abs/2505.01420
+            authors: >-
+              Mary Phuong, Roland S. Zimmermann, Ziyue Wang, David Lindner, Victoria Krakovna, Sarah Cogan, Allan Dafoe,
+              Lewis Ho, Rohin Shah
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Large Language Models Often Know When They Are Being Evaluated
+            url: https://arxiv.org/abs/2505.23836
+            authors: Joe Needham, Giles Edkins, Govind Pimpale, Henning Bartsch, Marius Hobbhahn
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Probe-Rewrite-Evaluate: A Workflow for Reliable Benchmarks and Quantifying Evaluation Awareness"
+            url: https://arxiv.org/abs/2509.00591
+            authors: Lang Xiong, Nishant Bhargava, Jianhang Hong, Jeremy Chang, Haihao Liu, Vasu Sharma, Kevin Zhu
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Know Thyself? On the Incapability and Implications of AI Self-Recognition
+            url: https://arxiv.org/abs/2510.03399
+            authors: Xiaoyan Bai, Aryan Shrivastava, Ari Holtzman, Chenhao Tan
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Chain-of-Thought Snippets — Anti-Scheming
+            url: https://www.antischeming.ai/snippets
+            venue: antischeming.ai
+            kind: other
+          - title: AI Awareness
+            url: https://arxiv.org/pdf/2504.20084
+            authors: Xiaojian Li, Haoyuan Shi, Rongwu Xu, Wei Xu
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Do LLMs know what they're capable of? Why this matters for AI safety, and initial findings
+            url: https://lesswrong.com/posts/9tHEibBBhQCHEyFsa/do-llms-know-what-they-re-capable-of-why-this-matters-for-ai
+            authors: Casey Barkan, Sid Black, Oliver Sourbut
+            year: 2025
+            venue: LessWrong / AI Alignment Forum
+            kind: lesswrong
+          - title: Claude Sonnet 3.7 (often) knows when it's in alignment evaluations
+            url: https://lesswrong.com/posts/E3daBewppAiECN3Ao/claude-sonnet-3-7-often-knows-when-it-s-in-alignment
+            authors: Nicholas Goldowsky-Dill, Mikita Balesni, Jérémy Scheurer, Marius Hobbhahn
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: It's hard to make scheming evals look realistic for LLMs
+            url: https://lesswrong.com/posts/TBk2dbWkg2F7dB3jb/it-s-hard-to-make-scheming-evals-look-realistic-for-llms
+            authors: Igor Ivanov, Danil Kadochnikov
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+      - id: evals_steganography
+        name: Steganography evals
+        summary: >-
+          evaluate whether models can hide secret information or encoded reasoning in their outputs, such as in
+          chain-of-thought scratchpads, to evade monitoring.
+        theoryOfChange: >-
+          if models can use steganography, they could hide deceptive reasoning, bypassing safety monitoring and control
+          measures. By evaluating this capability, we can assess the risk of a model fooling its supervisors.
+        seeAlso: a:ai_deception, a:cot_monitoring
+        targetCase: worst-case
+        broadApproaches:
+          - behavioral
+        someNames:
+          - antonio-norelli
+          - michael-bronstein
+        estimatedFTEs: 1-10
+        critiques:
+          - >-
+            Chain-of-Thought Is Already Unfaithful (So Steganography is Irrelevant): [Reasoning Models Don't Always Say
+            What They Think.](https://assets.anthropic.com/m/71876fabef0f0ed4/original/reasoning_models_paper.pdf)
+        papers:
+          - title: LLMs can hide text in other text of the same length
+            url: https://arxiv.org/abs/2510.20075
+            authors: Antonio Norelli, Michael Bronstein
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Do reasoning models use their scratchpad like we do? Evidence from distilling paraphrases
+            url: https://alignment.anthropic.com/2025/distill-paraphrases/
+            year: 2025
+            venue: Anthropic Alignment Science Blog
+            kind: blog_post
+          - title: Early Signs of Steganographic Capabilities in Frontier LLMs
+            url: https://arxiv.org/abs/2507.02737
+            authors: Artur Zolkowski, Kei Nishimura-Gasparian, Robert McCarthy, Roland S. Zimmermann, David Lindner
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Large language models can learn and generalize steganographic chain-of-thought under process supervision
+            url: https://arxiv.org/abs/2506.01926
+            authors: >-
+              Joey Skaf, Luis Ibanez-Lissen, Robert McCarthy, Connor Watts, Vasil Georgiv, Hannes Whittingham, Lorena
+              Gonzalez-Manzano, David Lindner, Cameron Tice, Edward James Young, Puria Radmard
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Subliminal Learning: Language models transmit behavioral traits via hidden signals in data"
+            url: https://arxiv.org/abs/2507.14805
+            authors: Alex Cloud, Minh Le, James Chua, Jan Betley, Anna Sztyber-Betley, Jacob Hilton, Samuel Marks, Owain Evans
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+      - id: ai_deception
+        name: AI deception evals
+        summary: >-
+          research demonstrating that AI models, particularly agentic ones, can learn and execute deceptive behaviors
+          such as alignment faking, manipulation, and sandbagging.
+        theoryOfChange: >-
+          proactively discover, evaluate, and understand the mechanisms of AI deception (e.g., alignment faking,
+          manipulation, agentic deception) to prevent models from fooling human supervisors and causing harm.
+        seeAlso: a:evals_situational_awareness, a:evals_steganography, a:evals_sandbagging, a:cot_monitoring
+        targetCase: worst-case
+        someNames:
+          - cadenza
+          - fred-heiding
+          - simon-lermen
+          - andrew-kao
+          - myra-cheng
+          - cinoo-lee
+          - pranav-khadpe
+          - satyapriya-krishna
+          - andy-zou
+          - rahul-gupta
+        estimatedFTEs: 30-80
+        critiques:
+          - >-
+            A central criticism is that the evaluation scenarios are "artificial and contrived". [the
+            void](https://nostalgebraist.tumblr.com/post/785766737747574784/the-void) and [Lessons from a
+            Chimp](https://arxiv.org/abs/2507.03409) argue this research is "overattributing human traits" to models.
+        papers:
+          - title: "Liars' Bench: Evaluating Lie Detectors for Language Models"
+            url: https://arxiv.org/abs/2511.16035
+          - title: The MASK Evaluation
+            url: https://huggingface.co/datasets/cais/MASK
+            venue: Hugging Face
+            kind: dataset_benchmark
+          - title: "Alignment Faking Revisited: Improved Classifiers and Open Source Extensions"
+            url: https://alignment.anthropic.com/2025/alignment-faking-revisited/
+            authors: John Hughes, Abhay Sheshadr
+            year: 2025
+            venue: Anthropic Alignment Science Blog
+            kind: blog_post
+          - title: "DeceptionBench: A Comprehensive Benchmark for AI Deception Behaviors in Real-world Scenarios"
+            url: https://arxiv.org/pdf/2510.15501
+            authors: Yao Huang, Yitong Sun, Yichi Zhang, Ruochen Zhang, Yinpeng Dong, Xingxing Wei
+            year: 2025
+            venue: NeurIPS 2025
+            kind: paper_preprint
+          - title: "Among Us: A Sandbox for Measuring and Detecting Agentic Deception"
+            url: https://arxiv.org/abs/2504.04072
+            authors: Satvik Golechha, Adrià Garriga-Alonso
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: >-
+              Evaluating Large Language Models' Capability to Launch Fully Automated Spear Phishing Campaigns: Validated
+              on Human Subjects
+            url: https://arxiv.org/abs/2412.00586
+            authors: Fred Heiding, Simon Lermen, Andrew Kao, Bruce Schneier, Arun Vishwanath
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: "D-REX: A Benchmark for Detecting Deceptive Reasoning in Large Language Models"
+            url: https://arxiv.org/abs/2509.17938
+            authors: >-
+              Satyapriya Krishna, Andy Zou, Rahul Gupta, Eliot Krzysztof Jones, Nick Winter, Dan Hendrycks, J. Zico
+              Kolter, Matt Fredrikson, Spyros Matsoukas
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Why Do Some Language Models Fake Alignment While Others Don't?
+            url: https://arxiv.org/pdf/2506.18032
+            authors: Abhay Sheshadri, John Hughes, Julian Michael, Alex Mallen, Arun Jose, Janus, Fabien Roger
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Frontier Models are Capable of In-context Scheming
+            url: https://arxiv.org/abs/2412.04984
+            authors: Alexander Meinke, Bronson Schoen, Jérémy Scheurer, Mikita Balesni, Rusheb Shah, Marius Hobbhahn
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: Evaluating & Reducing Deceptive Dialogue From Language Models with Multi-turn RL
+            url: https://arxiv.org/abs/2510.14318
+            authors: Marwa Abdulhai, Ryan Cheng, Aryansh Shrivastava, Natasha Jaques, Yarin Gal, Sergey Levine
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Eliciting Secret Knowledge from Language Models
+            url: https://arxiv.org/abs/2510.01070
+            authors: Bartosz Cywiński, Emil Ryd, Rowan Wang, Senthooran Rajamanoharan, Neel Nanda, Arthur Conmy, Samuel Marks
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Edge Cases in AI Alignment
+            url: https://lesswrong.com/posts/bqWihHtDnDseyfF2T/edge-cases-in-ai-alignment-2
+            authors: Florian Dietz
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: I replicated the Anthropic alignment faking experiment on other models, and they didn't fake alignment
+            url: https://lesswrong.com/posts/pCMmLiBcHbKohQgwA/i-replicated-the-anthropic-alignment-faking-experiment-on
+            authors: Aleksandr Kedrik, Igor Ivanov
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: Mistral Large 2 (123B) seems to exhibit alignment faking
+            url: https://lesswrong.com/posts/kCGk5tp5suHoGwhCa/mistral-large-2-123b-seems-to-exhibit-alignment-faking
+            authors: >-
+              Marc Carauleanu, Diogo de Lucena, Gunnar Zarncke, Cameron Berg, Judd Rosenblatt, Mike Vaiana, Trent
+              Hodgeson
+            year: 2025
+            venue: LessWrong/AI Alignment Forum
+            kind: lesswrong
+      - id: evals_sandbagging
+        name: Sandbagging evals
+        summary: >-
+          Evaluate whether AI models deliberately hide their true capabilities or underperform, especially when they
+          detect they are in an evaluation context.
+        theoryOfChange: >-
+          If models can distinguish between evaluation and deployment contexts ("evaluation awareness"), they might
+          learn to "sandbag" or deliberately underperform to hide dangerous capabilities, fooling safety evaluations. By
+          developing evaluations for sandbagging, we can test whether our safety methods are being deceived and detect
+          this behavior before a model is deployed.
+        seeAlso: a:ai_deception, a:evals_situational_awareness, a:various_redteams
+        targetCase: pessimistic
+        broadApproaches:
+          - behavioral
+        someNames:
+          - teun-van-der-weij
+          - cameron-tice
+          - chloe-li
+          - johannes-gasteiger
+          - joseph-bloom
+          - joel-dyer
+        estimatedFTEs: 10-50
+        critiques:
+          - >-
+            The main external critique, from sources like "[the
+            void](https://nostalgebraist.tumblr.com/post/785766737747574784/the-void)" and "[Lessons from a
+            Chimp](https://arxiv.org/abs/2507.03409)", is that this research "overattribut\[es\] human traits" to
+            models. It argues that what's being measured isn't genuine sandbagging but models "playing-along-with-drama
+            behaviour" in response to "artificial and contrived" evals.
+        papers:
+          - title: Strategic Dishonesty Can Undermine AI Safety Evaluations of Frontier LLMs
+            url: https://arxiv.org/abs/2509.18058
+            authors: >-
+              Alexander Panfilov, Evgenii Kortukov, Kristina Nikolić, Matthias Bethge, Sebastian Lapuschkin, Wojciech
+              Samek, Ameya Prabhu, Maksym Andriushchenko, Jonas Geiping
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "AI Sandbagging: Language Models can Strategically Underperform on Evaluations"
+            url: https://arxiv.org/abs/2406.07358
+            authors: Teun van der Weij, Felix Hofstätter, Ollie Jaffe, Samuel F. Brown, Francis Rhys Ward
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: Noise Injection Reveals Hidden Capabilities of Sandbagging Language Models
+            url: https://arxiv.org/pdf/2412.01784
+            authors: >-
+              Cameron Tice, Philipp Alexander Kreer, Nathan Helm-Burger, Prithviraj Singh Shahani, Fedor Ryzhenkov,
+              Jacob Haimes, Felix Hofstätter, Teun van der Weij
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: Sandbagging in a Simple Survival Bandit Problem
+            url: https://arxiv.org/pdf/2509.26239
+            authors: Joel Dyer, Daniel Jarne Ornia, Nicholas Bishop, Anisoara Calinescu, Michael Wooldridge
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Automated Researchers Can Subtly Sandbag
+            url: https://alignment.anthropic.com/2025/automated-researchers-sandbag/
+            authors: >-
+              Johannes Gasteiger, Vladimir Mikulik, Ethan Perez, Fabien Roger, Misha Wagner, Akbir Khan, Sam Bowman, Jan
+              Leike
+            year: 2025
+            venue: Anthropic Alignment Science Blog
+            kind: blog_post
+          - title: White Box Control at UK AISI - Update on Sandbagging Investigations
+            url: https://www.alignmentforum.org/posts/pPEeMdgjpjHZWCDFw/white-box-control-at-uk-aisi-update-on-sandbagging
+            authors: >-
+              Joseph Bloom, Jordan Taylor, Connor Kissane, Sid Black, merizian, alexdzm, jacoba, Ben Millwood, Alan
+              Cooney
+            year: 2025
+            venue: AI Alignment Forum
+            kind: lesswrong
+          - title: "Won't vs. Can't: Sandbagging-like Behavior from Claude Models"
+            url: https://alignment.anthropic.com/2025/wont-vs-cant/
+            year: 2025
+            venue: Anthropic Alignment Science Blog
+            kind: blog_post
+          - title: LLMs Can Covertly Sandbag on Capability Evaluations Against Chain-of-Thought Monitoring
+            url: https://arxiv.org/abs/2508.00943
+            authors: Chloe Li, Mary Phuong, Noah Y. Siegel
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Misalignment and Strategic Underperformance: An Analysis of Sandbagging and Exploration Hacking"
+            url: https://lesswrong.com/posts/TeTegzR8X5CuKgMc3/misalignment-and-strategic-underperformance-an-analysis-of
+            authors: Buck Shlegeris, Julian Stastny
+            year: 2025
+            venue: LessWrong / AI Alignment Forum
+            kind: lesswrong
+      - id: evals_self_replication
+        name: Self-replication evals
+        summary: >-
+          evaluate whether AI agents can autonomously replicate themselves by obtaining their own weights, securing
+          compute resources, and creating copies of themselves.
+        theoryOfChange: >-
+          if AI agents gain the ability to self-replicate, they could proliferate uncontrollably, making them impossible
+          to shut down. By measuring this capability with benchmarks like RepliBench, we can identify when models cross
+          this dangerous "red line" and implement controls before losing containment.
+        seeAlso: a:evals_autonomy, a:evals_situational_awareness
+        orthodoxProblems:
+          - "5"
+        targetCase: worst-case
+        broadApproaches:
+          - behavioral
+        someNames:
+          - sid-black
+          - asa-cooper-stickland
+          - jake-pencharz
+          - oliver-sourbut
+          - michael-schmatz
+          - jay-bailey
+          - ollie-matthews
+          - ben-millwood
+          - alex-remedios
+          - alan-cooney
+          - xudong-pan
+          - jiarun-dai
+          - yihe-fan
+        estimatedFTEs: 10-20
+        critiques:
+          - "[AI Sandbagging](https://arxiv.org/abs/2406.07358)"
+        papers:
+          - title: "Dive into the Agent Matrix: A Realistic Evaluation of Self-Replication Risk in LLM Agents"
+            url: https://arxiv.org/abs/2509.25302
+            authors: Boxuan Zhang, Yi Yu, Jiaxuan Guo, Jing Shao
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "RepliBench: measuring autonomous replication capabilities in AI systems"
+            url: https://aisi.gov.uk/work/replibench-measuring-autonomous-replication-capabilities-in-ai-systems
+            year: 2025
+            venue: UK AISI Blog
+            kind: blog_post
+          - title: Large language model-powered AI systems achieve self-replication with no human intervention
+            url: https://arxiv.org/abs/2503.17378
+            authors: Xudong Pan, Jiarun Dai, Yihe Fan, Minyuan Luo, Changyi Li, Min Yang
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+      - id: various_redteams
+        name: Various Redteams
+        summary: >-
+          attack current models and see what they do / deliberately induce bad things on current frontier models to test
+          out our theories / methods.
+        theoryOfChange: >-
+          to ensure models are safe, we must actively try to break them. By developing and applying a diverse suite of
+          attacks (e.g., in novel domains, against agentic systems, or using automated tools), researchers can discover
+          vulnerabilities, specification gaming, and deceptive behaviors before they are exploited, thereby informing
+          the development of more robust defenses.
+        seeAlso: a:evals_other
+        orthodoxProblems:
+          - "4"
+        targetCase: average-case
+        broadApproaches:
+          - behavioral
+        someNames:
+          - ryan-greenblatt
+          - benjamin-wright
+          - aengus-lynch
+          - john-hughes
+          - samuel-r-bowman
+          - andy-zou
+          - nicholas-carlini
+          - abhay-sheshadri
+        estimatedFTEs: 100+
+        critiques:
+          - >-
+            [Claude Sonnet 3.7 (often) knows when it's in alignment
+            evaluations](https://www.alignmentforum.org/posts/E3daBewppAiECN3Ao/claude-sonnet-3-7-often-knows-when-it-s-in-alignment),
+            [Red Teaming AI Red Teaming.](https://arxiv.org/html/2507.05538v1)
+        papers:
+          - title: Building and evaluating alignment auditing agents
+            url: https://alignment.anthropic.com/2025/automated-auditing/
+            authors: >-
+              Trenton Bricken, Rowan Wang, Sam Bowman, Euan Ong, Johannes Treutlein, Jeff Wu, Evan Hubinger, Samuel
+              Marks
+            year: 2025
+            venue: Alignment Science Blog
+            kind: blog_post
+          - title: "WildTeaming at Scale: From In-the-Wild Jailbreaks to (Adversarially) Safer Language Models"
+            url: https://arxiv.org/pdf/2406.18510
+            authors: >-
+              Liwei Jiang, Kavel Rao, Seungju Han, Allyson Ettinger, Faeze Brahman, Sachin Kumar, Niloofar
+              Mireshghallah, Ximing Lu, Maarten Sap, Yejin Choi, Nouha Dziri
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: Diverse and Effective Red Teaming with Auto-generated Rewards and Multi-step Reinforcement Learning
+            url: https://arxiv.org/abs/2412.18693
+            authors: Alex Beutel, Kai Xiao, Johannes Heidecke, Lilian Weng
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: Findings from a Pilot Anthropic—OpenAI Alignment Evaluation Exercise
+            url: https://t.co/wk0AP8aDNI
+            authors: >-
+              Samuel R. Bowman, Megha Srivastava, Jon Kutasov, Rowan Wang, Trenton Bricken, Benjamin Wright, Ethan
+              Perez, Nicholas Carlini
+            year: 2025
+            venue: Alignment Science Blog
+            kind: blog_post
+          - title: "Agentic Misalignment: How LLMs could be insider threats"
+            url: https://t.co/XFtd0H2Pzb
+            authors: >-
+              Aengus Lynch, Benjamin Wright, Caleb Larson, Kevin K. Troy, Stuart J. Ritchie, Sören Mindermann, Ethan
+              Perez, Evan Hubinger
+            year: 2025
+            venue: Anthropic Research
+            kind: blog_post
+          - title: Compromising Honesty and Harmlessness in Language Models via Deception Attacks
+            url: https://arxiv.org/abs/2502.08301
+            authors: Laurène Vaugrante, Francesca Carlon, Maluna Menke, Thilo Hagendorff
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Eliciting Language Model Behaviors with Investigator Agents
+            url: https://arxiv.org/abs/2502.01236
+            authors: >-
+              Xiang Lisa Li, Neil Chowdhury, Daniel D. Johnson, Tatsunori Hashimoto, Percy Liang, Sarah Schwettmann,
+              Jacob Steinhardt
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Why Do Some Language Models Fake Alignment While Others Don't?
+            url: https://arxiv.org/abs/2506.18032
+            authors: Abhay Sheshadri, John Hughes, Julian Michael, Alex Mallen, Arun Jose, Janus, Fabien Roger
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Demonstrating specification gaming in reasoning models
+            url: https://arxiv.org/abs/2502.13295
+            authors: Alexander Bondarenko, Denis Volk, Dmitrii Volkov, Jeffrey Ladish
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Call Me A Jerk: Persuading AI to Comply with Objectionable Requests"
+            url: https://t.co/tkHkVFVZ2m
+            authors: Lennart Meincke, Dan Shapiro, Angela Duckworth, Ethan R. Mollick, Lilach Mollick, Robert Cialdini
+            year: 2025
+            venue: SSRN / The Wharton School Research Paper
+            kind: paper_preprint
+          - title: "RedDebate: Safer Responses through Multi-Agent Red Teaming Debates"
+            url: https://arxiv.org/abs/2506.11083
+            authors: Ali Asad, Stephen Obadinma, Radin Shayanfar, Xiaodan Zhu
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Untitled
+            url: https://arxiv.org/abs/2512.03771
+          - title: The Structural Safety Generalization Problem
+            url: https://arxiv.org/abs/2504.09712
+            authors: >-
+              Julius Broomfield, Tom Gibbs, Ethan Kosak-Hine, George Ingebretsen, Tia Nasir, Jason Zhang, Reihaneh
+              Iranmanesh, Sara Pieri, Reihaneh Rabbany, Kellin Pelrine
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: No, of Course I Can! Deeper Fine-Tuning Attacks That Bypass Token-Level Safety Mechanisms
+            url: https://arxiv.org/abs/2502.19537
+            authors: >-
+              Joshua Kazdan, Abhay Puri, Rylan Schaeffer, Lisa Yu, Chris Cundy, Jason Stanley, Sanmi Koyejo,
+              Krishnamurthy Dvijotham
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Fundamental Limitations in Pointwise Defences of LLM Finetuning APIs
+            url: https://arxiv.org/abs/2502.14828
+            authors: >-
+              Xander Davies, Eric Winsor, Alexandra Souly, Tomek Korbak, Robert Kirk, Christian Schroeder de Witt, Yarin
+              Gal
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: LLM Robustness Leaderboard v1 --Technical report
+            url: https://arxiv.org/abs/2508.06296
+            authors: Pierre Peigné - Lefebvre, Quentin Feuillade-Montixi, Tom David, Nicolas Miailhe
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: >-
+              Jailbreak Defense in a Narrow Domain: Limitations of Existing Methods and a New Transcript-Classifier
+              Approach
+            url: https://arxiv.org/abs/2412.02159
+            authors: >-
+              Tony T. Wang, John Hughes, Henry Sleight, Rylan Schaeffer, Rajashree Agrawal, Fazl Barez, Mrinank Sharma,
+              Jesse Mu, Nir Shavit, Ethan Perez
+            year: 2024
+            venue: arXiv
+            kind: paper_preprint
+          - title: Discovering Undesired Rare Behaviors via Model Diff Amplification
+            url: https://www.goodfire.ai/papers/model-diff-amplification
+            authors: Santiago Aranguri, Thomas McGrath
+            year: 2025
+            venue: Goodfire Research
+            kind: blog_post
+          - title: >-
+              REINFORCE Adversarial Attacks on Large Language Models: An Adaptive, Distributional, and Semantic
+              Objective
+            url: https://arxiv.org/abs/2502.17254
+            authors: >-
+              Simon Geisler, Tom Wollschläger, M. H. I. Abdalla, Vincent Cohen-Addad, Johannes Gasteiger, Stephan
+              Günnemann
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Petri: An open-source auditing tool to accelerate AI safety research"
+            url: https://alignment.anthropic.com/2025/petri/
+            year: 2025
+            venue: Anthropic Alignment Science Blog
+            kind: blog_post
+          - title: "'For Argument's Sake, Show Me How to Harm Myself!': Jailbreaking LLMs in Suicide and Self-Harm Contexts"
+            url: https://arxiv.org/pdf/2507.02990
+            authors: Annika M Schoene, Cansu Canca
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: >-
+              Winning at All Cost: A Small Environment for Eliciting Specification Gaming Behaviors in Large Language
+              Models
+            url: https://arxiv.org/abs/2505.07846
+            authors: Lars Malmqvist
+            year: 2025
+            venue: arXiv (to be presented at SIMLA@ACNS 2025)
+            kind: paper_preprint
+          - title: Trading Inference-Time Compute for Adversarial Robustness
+            url: https://openai.com/index/trading-inference-time-compute-for-adversarial-robustness
+            authors: OpenAI
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Can a Neural Network that only Memorizes the Dataset be Undetectably Backdoored?
+            url: https://openreview.net/forum?id=TD1NfQuVr6
+            authors: Matjaz Leonardis
+            year: 2025
+            venue: ODYSSEY 2025 Conference
+            kind: paper_preprint
+          - title: "Multi-Agent Step Race Benchmark: Assessing LLM Collaboration and Deception Under Pressure"
+            url: https://github.com/lechmazur/step_game
+            authors: lechmazur, eltociear
+            year: 2025
+            venue: GitHub
+            kind: code_tool
+          - title: Adaptive Attacks Break Defenses Against Indirect Prompt Injection Attacks on LLM Agents
+            url: https://arxiv.org/abs/2503.00061
+            authors: Qiusi Zhan, Richard Fang, Henil Shalin Panchal, Daniel Kang
+            year: 2025
+            venue: NAACL 2025 Findings
+            kind: paper_preprint
+          - title: "Quantifying the Unruly: A Scoring System for Jailbreak Tactics"
+            url: https://0din.ai/blog/quantifying-the-unruly-a-scoring-system-for-jailbreak-tactics
+            authors: Pedram Amini
+            year: 2025
+            venue: 0DIN.ai Blog
+            kind: blog_post
+          - title: Transferable Adversarial Attacks on Black-Box Vision-Language Models
+            url: https://arxiv.org/abs/2505.01050
+            authors: Kai Hu, Weichen Yu, Li Zhang, Alexander Robey, Andy Zou, Chengming Xu, Haoqi Hu, Matt Fredrikson
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Advancing Gemini's security safeguards
+            url: https://deepmind.google/discover/blog/advancing-geminis-security-safeguards/
+            authors: Google DeepMind Security & Privacy Research Team
+            year: 2025
+            venue: Google DeepMind Blog
+            kind: blog_post
+          - title: Shutdown Resistance in Large Language Models
+            url: https://arxiv.org/abs/2509.14260
+            authors: Jeremy Schlatter, Benjamin Weinstein-Raun, Jeffrey Ladish
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Stress Testing Deliberative Alignment for Anti-Scheming Training
+            url: https://arxiv.org/abs/2509.15541
+            authors: >-
+              Bronson Schoen, Evgenia Nitishinskaya, Mikita Balesni, Axel Højmark, Felix Hofstätter, Jérémy Scheurer,
+              Alexander Meinke, Jason Wolfe, Teun van der Weij, Alex Lloyd, Nicholas Goldowsky-Dill, Angela Fan, Andrei
+              Matveiakin, Rusheb Shah, Marcus Williams, Amelia Glaese, Boaz Barak, Wojciech Zaremba, Marius Hobbhahn
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Chain-of-Thought Hijacking
+            url: https://arxiv.org/abs/2510.26418
+            authors: Jianli Zhao, Tingchen Fu, Rylan Schaeffer, Mrinank Sharma, Fazl Barez
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "X-Teaming: Multi-Turn Jailbreaks and Defenses with Adaptive Multi-Agents"
+            url: https://arxiv.org/abs/2504.13203
+            authors: >-
+              Salman Rahman, Liwei Jiang, James Shiffer, Genglin Liu, Sheriff Issaka, Md Rizwan Parvez, Hamid Palangi,
+              Kai-Wei Chang, Yejin Choi, Saadia Gabriel
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Jailbreak-Tuning: Models Efficiently Learn Jailbreak Susceptibility"
+            url: https://arxiv.org/abs/2507.11630
+            authors: >-
+              Brendan Murphy, Dillon Bowen, Shahrad Mohammadzadeh, Tom Tseng, Julius Broomfield, Adam Gleave, Kellin
+              Pelrine
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Monitoring Decomposition Attacks in LLMs with Lightweight Sequential Monitors
+            url: https://arxiv.org/abs/2506.10949
+            authors: Chen Yueh-Han, Nitish Joshi, Yulin Chen, Maksym Andriushchenko, Rico Angell, He He
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "STACK: Adversarial Attacks on LLM Safeguard Pipelines"
+            url: https://arxiv.org/abs/2506.24068
+            authors: >-
+              Ian R. McKenzie, Oskar J. Hollinsworth, Tom Tseng, Xander Davies, Stephen Casper, Aaron D. Tucker, Robert
+              Kirk, Adam Gleave
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Adversarial Manipulation of Reasoning Models using Internal Representations
+            url: https://arxiv.org/abs/2507.03167
+            authors: Kureha Yamaguchi, Benjamin Etheridge, Andy Arditi
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Discovering Forbidden Topics in Language Models
+            url: https://arxiv.org/abs/2505.17441
+            authors: Can Rager, Chris Wendler, Rohit Gandikota, David Bau
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "RL-Obfuscation: Can Language Models Learn to Evade Latent-Space Monitors?"
+            url: https://arxiv.org/abs/2506.14261
+            authors: Rohan Gupta, Erik Jenner
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Jailbreak Transferability Emerges from Shared Representations
+            url: https://arxiv.org/abs/2506.12913
+            authors: Rico Angell, Jannik Brinkmann, He He
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Mitigating Many-Shot Jailbreaking
+            url: https://arxiv.org/abs/2504.09604
+            authors: Christopher M. Ackerman, Nina Panickssery
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Active Attacks: Red-teaming LLMs via Adaptive Environments"
+            url: https://arxiv.org/abs/2509.21947
+            authors: Taeyoung Yun, Pierre-Luc St-Charles, Jinkyoo Park, Yoshua Bengio, Minsu Kim
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "It's the Thought that Counts: Evaluating the Attempts of Frontier LLMs to Persuade on Harmful Topics"
+            url: https://arxiv.org/abs/2506.02873
+            authors: >-
+              Matthew Kowal, Jasper Timm, Jean-Francois Godbout, Thomas Costello, Antonio A. Arechar, Gordon Pennycook,
+              David Rand, Adam Gleave, Kellin Pelrine
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Adversarial Attacks on Robotic Vision Language Action Models
+            url: https://arxiv.org/abs/2506.03350
+            authors: >-
+              Eliot Krzysztof Jones, Alexander Robey, Andy Zou, Zachary Ravichandran, George J. Pappas, Hamed Hassani,
+              Matt Fredrikson, J. Zico Kolter
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "MMDT: Decoding the Trustworthiness and Safety of Multimodal Foundation Models"
+            url: https://arxiv.org/abs/2503.14827
+            authors: >-
+              Chejian Xu, Jiawei Zhang, Zhaorun Chen, Chulin Xie, Mintong Kang, Yujin Potter, Zhun Wang, Zhuowen Yuan,
+              Alexander Xiong, Zidi Xiong, Chenhui Zhang, Lingzhi Yuan, Yi Zeng, Peiyang Xu, Chengquan Guo, Andy Zhou,
+              Jeffrey Ziwei Tan, Xuandong Zhao, Francesco Pinto, Zhen Xiang, Yu Gai, Zinan Lin, Dan Hendrycks, Bo Li,
+              Dawn Song
+            year: 2025
+            venue: ICLR 2025 (preprint on arXiv)
+            kind: paper_preprint
+          - title: Toward Understanding the Transferability of Adversarial Suffixes in Large Language Models
+            url: https://arxiv.org/abs/2510.22014
+            authors: Sarah Ball, Niki Hasrati, Alexander Robey, Avi Schwarzschild, Frauke Kreuter, Zico Kolter, Andrej Risteski
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Uncovering Gaps in How Humans and LLMs Interpret Subjective Language
+            url: https://arxiv.org/abs/2503.04113
+            authors: Erik Jones, Arjun Patrawala, Jacob Steinhardt
+            year: 2025
+            venue: ICLR 2025
+            kind: paper_preprint
+          - title: "RedCodeAgent: Automatic Red-teaming Agent against Diverse Code Agents"
+            url: https://arxiv.org/abs/2510.02609
+            authors: Chengquan Guo, Chulin Xie, Yu Yang, Zhaorun Chen, Zinan Lin, Xander Davies, Yarin Gal, Dawn Song, Bo Li
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "MIP against Agent: Malicious Image Patches Hijacking Multimodal OS Agents"
+            url: https://arxiv.org/abs/2503.10809
+            authors: Lukas Aichberger, Alasdair Paren, Guohao Li, Philip Torr, Yarin Gal, Adel Bibi
+            year: 2025
+            venue: arXiv (accepted NeurIPS 2025)
+            kind: paper_preprint
+          - title: "ToolTweak: An Attack on Tool Selection in LLM-based Agents"
+            url: https://arxiv.org/abs/2510.02554
+            authors: >-
+              Jonathan Sneh, Ruomei Yan, Jialin Yu, Philip Torr, Yarin Gal, Sunando Sengupta, Eric Sommerlade, Alasdair
+              Paren, Adel Bibi
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Adversarial Alignment for LLMs Requires Simpler, Reproducible, and More Measurable Objectives
+            url: https://arxiv.org/abs/2502.11910
+            authors: >-
+              Leo Schwinn, Yan Scholten, Tom Wollschläger, Sophie Xhonneux, Stephen Casper, Stephan Günnemann, Gauthier
+              Gidel
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Agentic Misalignment: How LLMs Could be Insider Threats"
+            url: https://lesswrong.com/posts/b8eeCGe3FWzHKbePF/agentic-misalignment-how-llms-could-be-insider-threats-1
+            authors: >-
+              Aengus Lynch, Benjamin Wright, Caleb Larson, Stuart Richie, Sören Mindermann, Evan Hubinger, Ethan Perez,
+              Kevin Troy
+            year: 2025
+            venue: LessWrong/AI Alignment Forum
+            kind: lesswrong
+          - title: >-
+              Illusory Safety: Redteaming DeepSeek R1 and the Strongest Fine-Tunable Models of OpenAI, Anthropic, and
+              Google
+            url: https://lesswrong.com/posts/zjqrSKZuRLnjAniyo/illusory-safety-redteaming-deepseek-r1-and-the-strongest
+            authors: >-
+              ChengCheng, Brendan Murphy, Adrià Garriga-alonso, Yashvardhan Sharma, dsbowen, smallsilo, Yawen Duan,
+              ChrisCundy, Hannah Betts, AdamGleave, Kellin Pelrine
+            year: 2025
+            venue: LessWrong / AI Alignment Forum
+            kind: lesswrong
+          - title: Will alignment-faking Claude accept a deal to reveal its misalignment?
+            url: https://lesswrong.com/posts/7C4KJot4aN8ieEDoz/will-alignment-faking-claude-accept-a-deal-to-reveal-its
+            authors: Ryan Greenblatt, Kyle Fish
+            year: 2025
+            venue: LessWrong / AI Alignment Forum
+            kind: lesswrong
+          - title: Research directions Open Phil wants to fund in technical AI safety
+            url: https://lesswrong.com/posts/26SHhxK2yYQbh7ors/research-directions-open-phil-wants-to-fund-in-technical-ai
+            authors: jake_mendel, maxnadeau, Peter Favaloro
+            year: 2025
+            venue: LessWrong
+            kind: agenda_manifesto
+          - title: When does Claude sabotage code? An Agentic Misalignment follow-up
+            url: https://lesswrong.com/posts/9i6fHMn2vTqyzAi9o/when-does-claude-sabotage-code-an-agentic-misalignment
+            authors: Nathan Delisle
+            year: 2024
+            venue: LessWrong
+            kind: lesswrong
+          - title: "Petri: An open-source auditing tool to accelerate AI safety research"
+            url: https://lesswrong.com/posts/kffbZGa2yYhc6cakc/petri-an-open-source-auditing-tool-to-accelerate-ai-safety
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+      - id: evals_other
+        name: Other evals
+        summary: >-
+          A collection of miscellaneous evaluations for specific alignment properties, such as honesty, shutdown
+          resistance and sycophancy.
+        theoryOfChange: >-
+          By developing novel benchmarks for specific, hard-to-measure properties (like honesty), critiquing the
+          reliability of existing methods (like cultural surveys), and improving the formal rigor of evaluation systems
+          (like LLM-as-Judges), researchers can create a more robust and comprehensive suite of evaluations to catch
+          failures missed by standard capability or safety testing.
+        seeAlso: other more specific sections on evals
+        targetCase: average-case
+        broadApproaches:
+          - behavioral
+        someNames:
+          - richard-ren
+          - mantas-mazeika
+          - andrs-corrada-emmanuel
+          - ariba-khan
+          - stephen-casper
+        estimatedFTEs: 20-50
+        critiques:
+          - >-
+            [The Unreliability of Evaluating Cultural Alignment in LLMs](https://arxiv.org/abs/2503.08688), [The
+            Leaderboard Illusion](https://arxiv.org/abs/2504.20879)
+        papers:
+          - title: Shutdown Resistance in Large Language Models
+            url: https://arxiv.org/abs/2509.14260
+            authors: Jeremy Schlatter, Benjamin Weinstein-Raun, Jeffrey Ladish
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Gödel's Therapy Room — Where Alignment Goes to Die | LLM Eval Harness | Leaderboard
+            url: https://gtr.dev/
+            year: 2025
+            venue: gtr.dev
+            kind: other
+          - title: AI Testing Should Account for Sophisticated Strategic Behaviour
+            url: https://arxiv.org/abs/2508.14927
+            authors: Vojtech Kovarik, Eric Olav Chen, Sami Petersen, Alexis Ghersengorin, Vincent Conitzer
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Logical Consistency Between Disagreeing Experts and Its Role in AI Safety
+            url: https://arxiv.org/abs/2510.00821
+            authors: Andrés Corrada-Emmanuel
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Expanding on what we missed with sycophancy
+            url: https://openai.com/index/expanding-on-sycophancy/
+            year: 2025
+            venue: OpenAI Blog
+            kind: blog_post
+          - title: Expressing stigma and inappropriate responses prevents LLMs from safely replacing mental health providers
+            url: https://arxiv.org/abs/2504.18412
+            authors: Jared Moore, Declan Grabb, William Agnew, Kevin Klyman, Stevie Chancellor, Desmond C. Ong, Nick Haber
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Spiral-Bench
+            url: https://eqbench.com/spiral-bench.html
+            authors: Sam Paech
+            venue: eqbench.com
+            kind: dataset_benchmark
+          - title: "Lessons from a Chimp: AI \"Scheming\" and the Quest for Ape Language"
+            url: https://arxiv.org/abs/2507.03409
+            authors: >-
+              Christopher Summerfield, Lennart Luettgau, Magda Dubois, Hannah Rose Kirk, Kobi Hackenburg, Catherine
+              Fist, Katarina Slama, Nicola Ding, Rebecca Anselmetti, Andrew Strait, Mario Giulianelli, Cozmin Ududec
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Syco-bench: A Benchmark for LLM Sycophancy"
+            url: https://www.syco-bench.com/
+            authors: Tim Duffy
+            venue: GitHub/Personal Project
+            kind: dataset_benchmark
+          - title: Sycophantic AI Decreases Prosocial Intentions and Promotes Dependence
+            url: https://www.arxiv.org/abs/2510.01395
+            authors: Myra Cheng, Cinoo Lee, Pranav Khadpe, Sunny Yu, Dyllan Han, Dan Jurafsky
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "OpenAgentSafety: A Comprehensive Framework for Evaluating Real-World AI Agent Safety"
+            url: https://arxiv.org/abs/2507.06134
+            authors: >-
+              Sanidhya Vijayvargiya, Aditya Bharat Soni, Xuhui Zhou, Zora Zhiruo Wang, Nouha Dziri, Graham Neubig,
+              Maarten Sap
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: "Discerning What Matters: A Multi-Dimensional Assessment of Moral Competence in LLMs"
+            url: https://arxiv.org/abs/2506.13082
+            authors: Daniel Kilov, Caroline Hendy, Secil Yanik Guyot, Aaron J. Snoswell, Seth Lazar
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: Establishing Best Practices for Building Rigorous Agentic Benchmarks
+            url: https://arxiv.org/abs/2507.02825
+            authors: >-
+              Yuxuan Zhu, Tengjun Jin, Yada Pruksachatkun, Andy Zhang, Shu Liu, Sasha Cui, Sayash Kapoor, Shayne
+              Longpre, Kevin Meng, Rebecca Weiss, Fazl Barez, Rahul Gupta, Jwala Dhamala, Jacob Merizian, Mario
+              Giulianelli, Harry Coppock, Cozmin Ududec, Jasjeet Sekhon, Jacob Steinhardt, Antony Kellermann, Sarah
+              Schwettmann, Matei Zaharia, Ion Stoica, Percy Liang, Daniel Kang
+            year: 2025
+            venue: arXiv
+            kind: paper_preprint
+          - title: >-
+              Do LLMs Comply Differently During Tests? Is This a Hidden Variable in Safety Evaluation? And Can We Steer
+              That?
+            url: https://lesswrong.com/posts/B2o6nrxwKxLPsSYdh/do-llms-comply-differently-during-tests-is-this-a-hidden
+            authors: Sahar Abdelnabi, Ahmed Salem
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: >-
+              Systematic runaway-optimiser-like LLM failure modes on Biologically and Economically aligned AI safety
+              benchmarks for LLMs with simplified observation format (BioBlue)
+            url: https://lesswrong.com/posts/PejNckwQj3A2MGhMA/systematic-runaway-optimiser-like-llm-failure-modes-on
+            authors: Roland Pihlakas, Sruthi Susan Kuriakose, Shruti Datta Gupta
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong
+          - title: Towards Alignment Auditing as a Numbers-Go-Up Science
+            url: https://lesswrong.com/posts/bGYQgBPEyHidnZCdE/towards-alignment-auditing-as-a-numbers-go-up-science
+            authors: Sam Marks
+            year: 2025
+            venue: LessWrong
+            kind: lesswrong

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -2,6 +2,9 @@ export interface Paper {
   title: string;
   url: string;
   authors?: string;
+  year?: number;
+  venue?: string;
+  kind?: string;
 }
 
 export interface OrthodoxProblem {


### PR DESCRIPTION
This tried to import the data from the updated "agendas.yaml". I think this mostly worked, but Claude highlighted some issues:

<img width="1241" height="805" alt="image" src="https://github.com/user-attachments/assets/8c430033-feef-4f22-883f-4626362e6a78" />



## Summary
- Update `agendas.yaml` with converted data from the shallow-review pipeline (77 agendas, 776 papers across 8 sections)
- Separate `lesswrongTags` into a new `agendaLesswrongTags.yaml` file for independent maintenance
- Add conversion script `scripts/convert-parsed-yaml.js` for future pipeline updates

## Details

### New Data Structure
The agendas now include richer paper metadata:
- `year`, `venue`, `kind` (e.g., `paper_preprint`, `blog_post`, `lesswrong`)
- Full author lists from the pipeline

### LessWrong Tags Separation
`lesswrongTags` are now stored in a separate file (`src/data/agendaLesswrongTags.yaml`) and merged at load time. This allows:
- Regenerating `agendas.yaml` from the pipeline without losing curated tags
- Independent maintenance of tag mappings

### Conversion Script Usage
To update from new pipeline data:
```bash
node scripts/convert-parsed-yaml.js <input.yaml> src/data/agendas.yaml
```

## Test plan
- [x] Build succeeds (`npm run build`)
- [ ] Verify pages render correctly with new data
- [ ] Check that lesswrongTags still appear on agenda pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)